### PR TITLE
[#43] refactor: 차량 수정 API 수정 로직 change 메소드로 변경

### DIFF
--- a/rest/src/main/java/com/wherecar/rest/domain/Car.java
+++ b/rest/src/main/java/com/wherecar/rest/domain/Car.java
@@ -41,4 +41,42 @@ public class Car extends BaseEntity{
 
     private Double batteryVoltage;
 
+    public void changeMake(String make) {
+        this.make = make;
+    }
+
+    public void changeModel(String model) {
+        this.model = model;
+    }
+
+    public void changeYear(String year) {
+        this.year = year;
+    }
+
+    public void changeMileage(Double mileage) {
+        this.mileage = mileage;
+    }
+
+    public void changeMdn(String mdn) {
+        this.mdn = mdn;
+    }
+
+    public void changeOwnerType(OwnerType ownerType) {
+        this.ownerType = ownerType;
+    }
+
+    public void changeAcquisitionType(AcquisitionType acquisitionType) {
+        this.acquisitionType = acquisitionType;
+    }
+
+    public void changeBatteryVoltage(Double batteryVoltage) {
+        this.batteryVoltage = batteryVoltage;
+    }
+
+    public void changeGeoInfo(GeoInfo geoInfo) {
+        this.geoInfo = geoInfo;
+    }
+
+
+
 }

--- a/rest/src/main/java/com/wherecar/rest/service/CarService.java
+++ b/rest/src/main/java/com/wherecar/rest/service/CarService.java
@@ -7,8 +7,8 @@ import java.util.List;
 
 public interface CarService {
 
-    void createCar(CarRegisterRequest registerCarRequest);
-    void updateCar(Long id, CarRegisterRequest registerCarRequest);
+    void createCar(CarRegisterRequest carRegisterRequest);
+    void updateCar(Long id, CarRegisterRequest carRegisterRequest);
     void deleteCar(Long id);
     List<CarResponse> getAllCars(int page, int size);
     CarResponse getCarDetails(Long id);

--- a/rest/src/main/java/com/wherecar/rest/service/CarServiceImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/service/CarServiceImpl.java
@@ -49,20 +49,18 @@ public class CarServiceImpl implements CarService {
     public void updateCar(Long id, CarRegisterRequest registerCarRequest) {
         Car car = carRepository.findById(id).orElseThrow(() -> new RuntimeException("차량을 찾을 수 없습니다."));
 
-        Car updatedCar = Car.builder()
-                .id(car.getId())
-                .make(registerCarRequest.getMake())
-                .model(registerCarRequest.getModel())
-                .year(registerCarRequest.getYear())
-                .mileage(registerCarRequest.getMileage())
-                .mdn(registerCarRequest.getMdn())
-                .ownerType(registerCarRequest.getOwnerType())
-                .acquisitionType(registerCarRequest.getAcquisitionType())
-                .batteryVoltage(registerCarRequest.getBatteryVoltage())
-                .company(car.getCompany())
-                .build();
+        car.changeMake(registerCarRequest.getMake());
+        car.changeModel(registerCarRequest.getModel());
+        car.changeYear(registerCarRequest.getYear());
+        car.changeMileage(registerCarRequest.getMileage());
+        car.changeMdn(registerCarRequest.getMdn());
+        car.changeOwnerType(registerCarRequest.getOwnerType());
+        car.changeAcquisitionType(registerCarRequest.getAcquisitionType());
+        car.changeBatteryVoltage(registerCarRequest.getBatteryVoltage());
 
-        carRepository.save(updatedCar);
+        //Todo: geoInfo 수정 기능 추가
+
+        carRepository.save(car);
     }
 
     @Override

--- a/rest/src/main/java/com/wherecar/rest/service/CarServiceImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/service/CarServiceImpl.java
@@ -25,20 +25,20 @@ public class CarServiceImpl implements CarService {
 //    private final CompanyRepository companyRepository;
 
     @Override
-    public void createCar(CarRegisterRequest registerCarRequest) {
+    public void createCar(CarRegisterRequest carRegisterRequest) {
 
 //        Company company = companyRepository.findById(registerCarRequest.getCompanyId())
 //                .orElseThrow(() -> new RuntimeException("Company 정보가 존재하지 않습니다."));
 
         Car car = Car.builder()
-                .make(registerCarRequest.getMake())
-                .model(registerCarRequest.getModel())
-                .year(registerCarRequest.getYear())
-                .mileage(registerCarRequest.getMileage())
-                .mdn(registerCarRequest.getMdn())
-                .ownerType(registerCarRequest.getOwnerType())
-                .acquisitionType(registerCarRequest.getAcquisitionType())
-                .batteryVoltage(registerCarRequest.getBatteryVoltage())
+                .make(carRegisterRequest.getMake())
+                .model(carRegisterRequest.getModel())
+                .year(carRegisterRequest.getYear())
+                .mileage(carRegisterRequest.getMileage())
+                .mdn(carRegisterRequest.getMdn())
+                .ownerType(carRegisterRequest.getOwnerType())
+                .acquisitionType(carRegisterRequest.getAcquisitionType())
+                .batteryVoltage(carRegisterRequest.getBatteryVoltage())
 //                .company(company)
                 .build();
 
@@ -46,17 +46,17 @@ public class CarServiceImpl implements CarService {
     }
 
     @Override
-    public void updateCar(Long id, CarRegisterRequest registerCarRequest) {
+    public void updateCar(Long id, CarRegisterRequest carRegisterRequest) {
         Car car = carRepository.findById(id).orElseThrow(() -> new RuntimeException("차량을 찾을 수 없습니다."));
 
-        car.changeMake(registerCarRequest.getMake());
-        car.changeModel(registerCarRequest.getModel());
-        car.changeYear(registerCarRequest.getYear());
-        car.changeMileage(registerCarRequest.getMileage());
-        car.changeMdn(registerCarRequest.getMdn());
-        car.changeOwnerType(registerCarRequest.getOwnerType());
-        car.changeAcquisitionType(registerCarRequest.getAcquisitionType());
-        car.changeBatteryVoltage(registerCarRequest.getBatteryVoltage());
+        car.changeMake(carRegisterRequest.getMake());
+        car.changeModel(carRegisterRequest.getModel());
+        car.changeYear(carRegisterRequest.getYear());
+        car.changeMileage(carRegisterRequest.getMileage());
+        car.changeMdn(carRegisterRequest.getMdn());
+        car.changeOwnerType(carRegisterRequest.getOwnerType());
+        car.changeAcquisitionType(carRegisterRequest.getAcquisitionType());
+        car.changeBatteryVoltage(carRegisterRequest.getBatteryVoltage());
 
         //Todo: geoInfo 수정 기능 추가
 


### PR DESCRIPTION
close #43 

## 📝 작업 내용

> 차량 수정 API에서 builder 대신 change 메소드로 수정 로직 변경

- `builder`를 사용한 기존 방식의 단점을 개선하기 위해, `change` 메소드를 사용하여 수정 로직을 변경했습니다.
-> 불필요한 객체 생성을 방지, setter 사용을 지양