### PR TITLE
[#89] feat: 운행일지 조회 API 필터링 기능 추가

### DIFF
--- a/rest/src/main/java/com/wherecar/rest/controller/CarLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/controller/CarLogController.java
@@ -2,7 +2,7 @@ package com.wherecar.rest.controller;
 
 import com.wherecar.rest.constants.PaginationConstants;
 import com.wherecar.rest.dto.CarLogDetailResponse;
-import com.wherecar.rest.dto.CarLogTimeFilterRequest;
+import com.wherecar.rest.dto.CarLogFilterRequest;
 import com.wherecar.rest.dto.CarLogsResponse;
 import com.wherecar.rest.dto.CarLogsUpdateRequest;
 import com.wherecar.rest.service.CarLogService;
@@ -23,35 +23,26 @@ class CarLogController {
 
     private final CarLogService carLogService;
 
-    //운행일지 목록 조회
-    @GetMapping
-    public ResponseEntity<List<CarLogsResponse>> carLogsGet(
-            @RequestParam(value = "page", defaultValue = "" + PaginationConstants.DEFAULT_PAGE) int page,
-            @RequestParam(value = "size", defaultValue = "" + PaginationConstants.DEFAULT_SIZE) int size) {
-
-        Long companyId = AuthUtil.getCompanyId();
-
-        List<CarLogsResponse> carLogs = carLogService.getCarLogs(companyId, page, size);
-        return ResponseEntity.ok(carLogs);
-    }
-
-    //차량 mdn으로 운행일지 목록 조회
-    @PostMapping("/cars/{mdn}")
-    public ResponseEntity<List<CarLogsResponse>> carLogsGetByCarMdn(
-            @PathVariable String mdn,
+    //운행일지 목록 조회 (filter 추가)
+    @PostMapping
+    public ResponseEntity<List<CarLogsResponse>> carLogsGetWithFilter(
             @RequestParam(value = "page", defaultValue = "" + PaginationConstants.DEFAULT_PAGE) int page,
             @RequestParam(value = "size", defaultValue = "" + PaginationConstants.DEFAULT_SIZE) int size,
-            @RequestBody(required = false) CarLogTimeFilterRequest timeFilter) {
+            @RequestBody(required = false) CarLogFilterRequest filterRequest) {
 
         Long companyId = AuthUtil.getCompanyId();
 
-        LocalDateTime startTime = timeFilter != null ? timeFilter.getStartTime() : null;
-        LocalDateTime endTime = timeFilter != null ? timeFilter.getEndTime() : null;
+        List<CarLogsResponse> carLogs = carLogService.getCarLogsFiltered(
+                companyId,
+                filterRequest.getMdn(),
+                filterRequest.getStartTime(),
+                filterRequest.getEndTime(),
+                page,
+                size
+        );
 
-        List<CarLogsResponse> carLogs = carLogService.getCarLogsByCarMdn(companyId, mdn, startTime, endTime, page, size);
         return ResponseEntity.ok(carLogs);
     }
-
 
     //운행일지 상세 정보 조회
     @GetMapping("/{logId}")

--- a/rest/src/main/java/com/wherecar/rest/controller/CarLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/controller/CarLogController.java
@@ -2,6 +2,7 @@ package com.wherecar.rest.controller;
 
 import com.wherecar.rest.constants.PaginationConstants;
 import com.wherecar.rest.dto.CarLogDetailResponse;
+import com.wherecar.rest.dto.CarLogTimeFilterRequest;
 import com.wherecar.rest.dto.CarLogsResponse;
 import com.wherecar.rest.dto.CarLogsUpdateRequest;
 import com.wherecar.rest.service.CarLogService;
@@ -11,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -34,17 +36,22 @@ class CarLogController {
     }
 
     //차량 mdn으로 운행일지 목록 조회
-    @GetMapping("/cars/{mdn}")
+    @PostMapping("/cars/{mdn}")
     public ResponseEntity<List<CarLogsResponse>> carLogsGetByCarMdn(
             @PathVariable String mdn,
             @RequestParam(value = "page", defaultValue = "" + PaginationConstants.DEFAULT_PAGE) int page,
-            @RequestParam(value = "size", defaultValue = "" + PaginationConstants.DEFAULT_SIZE) int size) {
+            @RequestParam(value = "size", defaultValue = "" + PaginationConstants.DEFAULT_SIZE) int size,
+            @RequestBody(required = false) CarLogTimeFilterRequest timeFilter) {
 
         Long companyId = AuthUtil.getCompanyId();
 
-        List<CarLogsResponse> carLogs = carLogService.getCarLogsByCarMdn(companyId, mdn, page, size);
+        LocalDateTime startTime = timeFilter != null ? timeFilter.getStartTime() : null;
+        LocalDateTime endTime = timeFilter != null ? timeFilter.getEndTime() : null;
+
+        List<CarLogsResponse> carLogs = carLogService.getCarLogsByCarMdn(companyId, mdn, startTime, endTime, page, size);
         return ResponseEntity.ok(carLogs);
     }
+
 
     //운행일지 상세 정보 조회
     @GetMapping("/{logId}")

--- a/rest/src/main/java/com/wherecar/rest/controller/CarLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/controller/CarLogController.java
@@ -9,6 +9,7 @@ import com.wherecar.rest.service.CarLogService;
 import com.wherecar.rest.user.auth.AuthUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -25,14 +26,17 @@ class CarLogController {
 
     //운행일지 목록 조회 (filter 추가)
     @PostMapping
-    public ResponseEntity<List<CarLogsResponse>> carLogsGetWithFilter(
+    public ResponseEntity<Page<CarLogsResponse>> carLogsGetWithFilter(
             @RequestParam(value = "page", defaultValue = "" + PaginationConstants.DEFAULT_PAGE) int page,
             @RequestParam(value = "size", defaultValue = "" + PaginationConstants.DEFAULT_SIZE) int size,
             @RequestBody(required = false) CarLogFilterRequest filterRequest) {
 
         Long companyId = AuthUtil.getCompanyId();
 
-        List<CarLogsResponse> carLogs = carLogService.getCarLogsFiltered(
+        CarLogFilterRequest request = filterRequest != null ? filterRequest : new CarLogFilterRequest();
+
+
+        Page<CarLogsResponse> carLogs = carLogService.getCarLogsFiltered(
                 companyId,
                 filterRequest.getMdn(),
                 filterRequest.getStartTime(),

--- a/rest/src/main/java/com/wherecar/rest/dto/CarLogFilterRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/dto/CarLogFilterRequest.java
@@ -11,7 +11,8 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-public class CarLogTimeFilterRequest {
+public class CarLogFilterRequest {
+    private String mdn;
     private LocalDateTime startTime;
     private LocalDateTime endTime;
 }

--- a/rest/src/main/java/com/wherecar/rest/dto/CarLogTimeFilterRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/dto/CarLogTimeFilterRequest.java
@@ -1,0 +1,17 @@
+package com.wherecar.rest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CarLogTimeFilterRequest {
+    private LocalDateTime startTime;
+    private LocalDateTime endTime;
+}

--- a/rest/src/main/java/com/wherecar/rest/dto/CarLogsResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/dto/CarLogsResponse.java
@@ -32,7 +32,5 @@ public class CarLogsResponse {
     private DriveType driveType;
     private String driver;
     private String description;
-    private CarState carStatus;
-
 
 }

--- a/rest/src/main/java/com/wherecar/rest/repository/CarLogRepository.java
+++ b/rest/src/main/java/com/wherecar/rest/repository/CarLogRepository.java
@@ -1,42 +1,36 @@
 package com.wherecar.rest.repository;
 
-import com.wherecar.rest.domain.Car;
 import com.wherecar.rest.domain.CarLog;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
-import java.util.Optional;
 
 public interface CarLogRepository extends JpaRepository<CarLog, Long> {
 
     @Query("SELECT cl FROM CarLog cl JOIN Car c ON cl.mdn = c.mdn WHERE c.company.id = :userCompanyId")
     Page<CarLog> findByCompanyId(@Param("userCompanyId") Long userCompanyId, Pageable pageable);
 
-    @Query("SELECT cl FROM CarLog cl JOIN Car c ON cl.mdn = c.mdn WHERE c.company.id = :userCompanyId AND c.mdn = :mdn")
-    Page<CarLog> findByCompanyIdAndCarId(@Param("userCompanyId") Long userCompanyId, @Param("mdn") String mdn, Pageable pageable);
-
     @Query("""
     SELECT cl
     FROM CarLog cl
     JOIN Car c ON cl.mdn = c.mdn
-    WHERE c.company.id = :userCompanyId
-      AND c.mdn = :mdn
+    WHERE c.company.id = :companyId
+      AND (:mdn IS NULL OR c.mdn = :mdn)
       AND (:startTime IS NULL OR cl.onTime >= :startTime)
       AND (:endTime IS NULL OR cl.onTime <= :endTime)
     """)
-    Page<CarLog> findByCompanyIdAndMdnAndPeriod(
-            @Param("userCompanyId") Long userCompanyId,
+    Page<CarLog> findCarLogsFiltered(
+            @Param("companyId") Long companyId,
             @Param("mdn") String mdn,
             @Param("startTime") LocalDateTime startTime,
             @Param("endTime") LocalDateTime endTime,
             Pageable pageable
     );
+
 
 
 }

--- a/rest/src/main/java/com/wherecar/rest/repository/CarLogRepository.java
+++ b/rest/src/main/java/com/wherecar/rest/repository/CarLogRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface CarLogRepository extends JpaRepository<CarLog, Long> {
@@ -19,5 +20,23 @@ public interface CarLogRepository extends JpaRepository<CarLog, Long> {
 
     @Query("SELECT cl FROM CarLog cl JOIN Car c ON cl.mdn = c.mdn WHERE c.company.id = :userCompanyId AND c.mdn = :mdn")
     Page<CarLog> findByCompanyIdAndCarId(@Param("userCompanyId") Long userCompanyId, @Param("mdn") String mdn, Pageable pageable);
+
+    @Query("""
+    SELECT cl
+    FROM CarLog cl
+    JOIN Car c ON cl.mdn = c.mdn
+    WHERE c.company.id = :userCompanyId
+      AND c.mdn = :mdn
+      AND (:startTime IS NULL OR cl.onTime >= :startTime)
+      AND (:endTime IS NULL OR cl.onTime <= :endTime)
+    """)
+    Page<CarLog> findByCompanyIdAndMdnAndPeriod(
+            @Param("userCompanyId") Long userCompanyId,
+            @Param("mdn") String mdn,
+            @Param("startTime") LocalDateTime startTime,
+            @Param("endTime") LocalDateTime endTime,
+            Pageable pageable
+    );
+
 
 }

--- a/rest/src/main/java/com/wherecar/rest/service/CarLogService.java
+++ b/rest/src/main/java/com/wherecar/rest/service/CarLogService.java
@@ -2,13 +2,14 @@ package com.wherecar.rest.service;
 
 import com.wherecar.rest.dto.*;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CarLogService {
 
     List<CarLogsResponse> getCarLogs(Long companyId, int page, int size);
 
-    List<CarLogsResponse> getCarLogsByCarMdn(Long companyId, String mdn, int page, int size);
+    List<CarLogsResponse> getCarLogsByCarMdn(Long companyId, String mdn, LocalDateTime startTime, LocalDateTime endTime, int page, int size);
 
     CarLogDetailResponse getCarLogsDetails(Long logId);
 

--- a/rest/src/main/java/com/wherecar/rest/service/CarLogService.java
+++ b/rest/src/main/java/com/wherecar/rest/service/CarLogService.java
@@ -7,9 +7,7 @@ import java.util.List;
 
 public interface CarLogService {
 
-    List<CarLogsResponse> getCarLogs(Long companyId, int page, int size);
-
-    List<CarLogsResponse> getCarLogsByCarMdn(Long companyId, String mdn, LocalDateTime startTime, LocalDateTime endTime, int page, int size);
+    List<CarLogsResponse> getCarLogsFiltered(Long companyId, String mdn, LocalDateTime startTime, LocalDateTime endTime, int page, int size);
 
     CarLogDetailResponse getCarLogsDetails(Long logId);
 

--- a/rest/src/main/java/com/wherecar/rest/service/CarLogService.java
+++ b/rest/src/main/java/com/wherecar/rest/service/CarLogService.java
@@ -1,13 +1,14 @@
 package com.wherecar.rest.service;
 
 import com.wherecar.rest.dto.*;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 public interface CarLogService {
 
-    List<CarLogsResponse> getCarLogsFiltered(Long companyId, String mdn, LocalDateTime startTime, LocalDateTime endTime, int page, int size);
+    Page<CarLogsResponse> getCarLogsFiltered(Long companyId, String mdn, LocalDateTime startTime, LocalDateTime endTime, int page, int size);
 
     CarLogDetailResponse getCarLogsDetails(Long logId);
 

--- a/rest/src/main/java/com/wherecar/rest/service/CarLogServiceImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/service/CarLogServiceImpl.java
@@ -28,17 +28,15 @@ public class CarLogServiceImpl implements CarLogService {
 
     private static final Integer METER_TO_KILOMETER = 1000;
 
-
-    // (운행일지 + 차량) 목록
+    //차량 목록 조회(필터 추가)
     @Override
-    @Transactional(readOnly = true)
-    public List<CarLogsResponse> getCarLogs(Long companyId, int page, int size) {
+    public List<CarLogsResponse> getCarLogsFiltered(Long companyId, String mdn, LocalDateTime startTime, LocalDateTime endTime, int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size);
 
-        PageRequest pageRequest = PageRequest.of(page,size);
+        Page<CarLog> logs = carLogRepository.findCarLogsFiltered(companyId, mdn, startTime, endTime, pageRequest);
 
-        Page<CarLog> carLogPage = carLogRepository.findByCompanyId(companyId, pageRequest);
-
-        return carLogPage.stream().map(carLog -> CarLogsResponse.builder()
+        return logs.stream()
+                .map(carLog -> CarLogsResponse.builder()
                         .logId(carLog.getId())
                         .mdn(carLog.getMdn())
                         .onTime(carLog.getOnTime())
@@ -52,32 +50,6 @@ public class CarLogServiceImpl implements CarLogService {
                 .collect(Collectors.toList());
     }
 
-    @Override
-    @Transactional(readOnly = true)
-    public List<CarLogsResponse> getCarLogsByCarMdn(Long companyId, String mdn, LocalDateTime startTime, LocalDateTime endTime, int page, int size) {
-
-        PageRequest pageRequest = PageRequest.of(page,size);
-
-        Page<CarLog> carLogPage = carLogRepository.findByCompanyIdAndMdnAndPeriod(companyId, mdn, startTime, endTime, pageRequest);
-
-        if (carLogPage.isEmpty()) {
-            throw new RuntimeException("해당 차량의 운행일지를 찾을 수 없습니다.");
-        }
-
-        return carLogPage.stream().map(carLog -> CarLogsResponse.builder()
-                        .logId(carLog.getId())
-                        .mdn(carLog.getMdn())
-                        .onTime(carLog.getOnTime())
-                        .offTime(carLog.getOffTime())
-                        .onMileage(carLog.getOnMileage())
-                        .offMileage(carLog.getOffMileage())
-                        .driver(carLog.getDriver())
-                        .driveType(carLog.getDriveType())
-                        .description(carLog.getDescription())
-                        .build())
-                .collect(Collectors.toList());
-
-    }
 
 
     //운행일지 상세 정보

--- a/rest/src/main/java/com/wherecar/rest/service/CarLogServiceImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/service/CarLogServiceImpl.java
@@ -30,25 +30,32 @@ public class CarLogServiceImpl implements CarLogService {
 
     //차량 목록 조회(필터 추가)
     @Override
-    public List<CarLogsResponse> getCarLogsFiltered(Long companyId, String mdn, LocalDateTime startTime, LocalDateTime endTime, int page, int size) {
+    public Page<CarLogsResponse> getCarLogsFiltered(
+            Long companyId,
+            String mdn,
+            LocalDateTime startTime,
+            LocalDateTime endTime,
+            int page,
+            int size
+    ) {
         PageRequest pageRequest = PageRequest.of(page, size);
 
         Page<CarLog> logs = carLogRepository.findCarLogsFiltered(companyId, mdn, startTime, endTime, pageRequest);
 
-        return logs.stream()
-                .map(carLog -> CarLogsResponse.builder()
-                        .logId(carLog.getId())
-                        .mdn(carLog.getMdn())
-                        .onTime(carLog.getOnTime())
-                        .offTime(carLog.getOffTime())
-                        .onMileage(carLog.getOnMileage())
-                        .offMileage(carLog.getOffMileage())
-                        .driver(carLog.getDriver())
-                        .driveType(carLog.getDriveType())
-                        .description(carLog.getDescription())
-                        .build())
-                .collect(Collectors.toList());
+        return logs.map(carLog -> CarLogsResponse.builder()
+                .logId(carLog.getId())
+                .mdn(carLog.getMdn())
+                .onTime(carLog.getOnTime())
+                .offTime(carLog.getOffTime())
+                .onMileage(carLog.getOnMileage())
+                .offMileage(carLog.getOffMileage())
+                .driver(carLog.getDriver())
+                .driveType(carLog.getDriveType())
+                .description(carLog.getDescription())
+                .build()
+        );
     }
+
 
 
 

--- a/rest/src/main/java/com/wherecar/rest/service/CarLogServiceImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/service/CarLogServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -46,17 +47,18 @@ public class CarLogServiceImpl implements CarLogService {
                         .offMileage(carLog.getOffMileage())
                         .driver(carLog.getDriver())
                         .driveType(carLog.getDriveType())
+                        .description(carLog.getDescription())
                         .build())
                 .collect(Collectors.toList());
     }
 
     @Override
     @Transactional(readOnly = true)
-    public List<CarLogsResponse> getCarLogsByCarMdn(Long companyId, String mdn, int page, int size) {
+    public List<CarLogsResponse> getCarLogsByCarMdn(Long companyId, String mdn, LocalDateTime startTime, LocalDateTime endTime, int page, int size) {
 
         PageRequest pageRequest = PageRequest.of(page,size);
 
-        Page<CarLog> carLogPage = carLogRepository.findByCompanyIdAndCarId(companyId, mdn, pageRequest);
+        Page<CarLog> carLogPage = carLogRepository.findByCompanyIdAndMdnAndPeriod(companyId, mdn, startTime, endTime, pageRequest);
 
         if (carLogPage.isEmpty()) {
             throw new RuntimeException("해당 차량의 운행일지를 찾을 수 없습니다.");
@@ -71,6 +73,7 @@ public class CarLogServiceImpl implements CarLogService {
                         .offMileage(carLog.getOffMileage())
                         .driver(carLog.getDriver())
                         .driveType(carLog.getDriveType())
+                        .description(carLog.getDescription())
                         .build())
                 .collect(Collectors.toList());
 

--- a/rest/src/main/resources/application.properties
+++ b/rest/src/main/resources/application.properties
@@ -3,7 +3,7 @@ spring.application.name=rest
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.datasource.url=jdbc:mysql://localhost:3306/wherecar
 spring.datasource.username=user
-spring.datasource.password=
+spring.datasource.password=1234
 
 spring.jpa.database-platform=org.hibernate.dialect.MySQLDialect
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
close #89

## 📝 작업 내용

> 운행일지 API 필터링 기능을 추가했습니다. 
- 기존 조회 API에 바디(mdn, startTime, endTime)를 추가할 수 있도록 해서 각각을 기준으로 필터링되도록 했습니다.
- 추가로 페이지네이션을 위해 페이지네이션 정보를 반환하도록 수정했습니다.
