### PR TITLE
[#122] feat: 차량 실시간 위치 전송 웹소켓 구현

### DIFF
--- a/rest/build.gradle
+++ b/rest/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'

--- a/rest/src/main/java/com/wherecar/rest/RestApplication.java
+++ b/rest/src/main/java/com/wherecar/rest/RestApplication.java
@@ -3,9 +3,11 @@ package com.wherecar.rest;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableJpaAuditing
 @SpringBootApplication
+@EnableScheduling
 public class RestApplication {
 
 	public static void main(String[] args) {

--- a/rest/src/main/java/com/wherecar/rest/dto/GpsPoint.java
+++ b/rest/src/main/java/com/wherecar/rest/dto/GpsPoint.java
@@ -1,14 +1,19 @@
 package com.wherecar.rest.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
+import lombok.Data;
 import lombok.Getter;
 
 import java.time.LocalDateTime;
 
 @Getter
 @Builder
+@Data
 public class GpsPoint {
     private double latitude;
     private double longitude;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime timestamp;
 }

--- a/rest/src/main/java/com/wherecar/rest/websocket/CarLocationSocketHandler.java
+++ b/rest/src/main/java/com/wherecar/rest/websocket/CarLocationSocketHandler.java
@@ -1,0 +1,200 @@
+package com.wherecar.rest.websocket;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.wherecar.rest.dto.CarResponse;
+import com.wherecar.rest.dto.GpsLogResponse;
+import com.wherecar.rest.dto.GpsPoint;
+import com.wherecar.rest.dto.GpsRouteResponse;
+import com.wherecar.rest.service.CarService;
+import com.wherecar.rest.service.GpsLogService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.socket.CloseStatus;
+import org.springframework.web.socket.TextMessage;
+import org.springframework.web.socket.WebSocketSession;
+import org.springframework.web.socket.handler.TextWebSocketHandler;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.*;
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class CarLocationSocketHandler extends TextWebSocketHandler {
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+    private final GpsLogService gpsLogService;
+    private final CarService carService;
+
+    private final Map<WebSocketSession, Long> companySubscriptions = new HashMap<>();
+
+    @Override
+    public void afterConnectionEstablished(WebSocketSession session) {
+        System.out.println("클라이언트 연결됨: " + session.getId());
+        companySubscriptions.put(session, null);
+    }
+
+    @Override
+    public void handleTextMessage(WebSocketSession session, TextMessage message) throws IOException {
+        JsonNode json = objectMapper.readTree(message.getPayload());
+
+        if ("subscribe".equals(json.get("type").asText())) {
+            Long companyId = json.get("companyId").asLong();
+            companySubscriptions.put(session, companyId);
+        }
+
+        sendLocationUpdates();
+    }
+
+    public void sendLocationUpdates() {
+
+        companySubscriptions.forEach((session, companyId) -> {
+            if (session.isOpen() && companyId != null) {
+
+                // 전체 차량 데이터 가줘오기
+                List<CarResponse> cars = carService.getAllCars(companyId,0,9999);
+
+                for(CarResponse car : cars) {
+                 log.info("차량 정보"+ car.getMdn());
+                }
+
+                List<Map<String, Object>> responseList = new ArrayList<>();
+
+                for (CarResponse car : cars) {
+
+                    //TODO: 실제 시간으로 변경
+                    //LocalDateTime now = LocalDateTime.now().withNano(0);
+                    LocalDateTime now = LocalDateTime.of(2025, 4, 1, 9, 1, 1, 0);
+
+                    LocalDateTime baseTime = now.minusMinutes(1);
+
+                    String carMdn = car.getMdn();
+
+                    // 1분간의 GPS 데이터 조회
+                    GpsRouteResponse result = gpsLogService.getRoute(carMdn, baseTime, now);
+                    log.info("경로 결과"+ result.getRoute());
+
+                    // 60초 기준 데이터 보정
+                    List<GpsPoint> filledPoints = fillTo60(carMdn, result.getRoute(), baseTime);
+
+                    Map<String, Object> carData = Map.of(
+                            "carId", carMdn,
+                            "locations", filledPoints
+                    );
+
+                    responseList.add(carData);
+                }
+
+
+                try {
+                    String json = objectMapper.writeValueAsString(responseList);
+                    session.sendMessage(new TextMessage(json));
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        });
+    }
+
+    @Override
+    public void afterConnectionClosed(WebSocketSession session, CloseStatus status) {
+        companySubscriptions.remove(session);
+    }
+
+    // 60개 미만이면 마지막 좌표 복사해서 채우기
+    private List<GpsPoint> fillTo60(String mdn, List<GpsPoint> rawList, LocalDateTime baseTime) {
+        List<GpsPoint> result = new ArrayList<>();
+        Map<LocalDateTime, GpsPoint> gpsMap = new HashMap<>();
+
+        // 시간 기준 Map으로 정리 (초 단위 정렬)
+        for (GpsPoint point : rawList) {
+            LocalDateTime ts = point.getTimestamp().withNano(0);
+            gpsMap.put(ts, point);
+        }
+
+        GpsPoint latest = null;
+
+        //rawList가 비어 있으면 미리 최신 위치 한 번만 조회
+        if (rawList.isEmpty()) {
+            GpsLogResponse latestLocation = gpsLogService.getLatestLocation(mdn);
+
+            for (int i = 0; i < 60; i++) {
+                LocalDateTime currentTime = baseTime.plusSeconds(i);
+
+                GpsPoint point;
+                if (latestLocation != null) {
+                    point = GpsPoint.builder()
+                            .latitude(latestLocation.getLatitude())
+                            .longitude(latestLocation.getLongitude())
+                            .timestamp(currentTime)
+                            .build();
+                } else {
+                    point = GpsPoint.builder()
+                            .latitude(0.0)
+                            .longitude(0.0)
+                            .timestamp(currentTime)
+                            .build();
+                }
+
+                result.add(point);
+            }
+
+            return result;
+        }
+
+        for (int i = 0; i < 60; i++) {
+            LocalDateTime currentTime = baseTime.plusSeconds(i);
+            GpsPoint point;
+
+            if (gpsMap.containsKey(currentTime)) {
+                point = gpsMap.get(currentTime);
+                latest = point;
+
+                log.info("gpsMap에서 찾은 좌표: {}", point);
+
+            } else if (latest != null) {
+                point = GpsPoint.builder()
+                        .latitude(latest.getLatitude())
+                        .longitude(latest.getLongitude())
+                        .timestamp(currentTime)
+                        .build();
+
+                log.info("최신 좌표 사용: {}", point);
+
+            } else {
+                GpsLogResponse latestLocation = gpsLogService.getLatestLocation(mdn);
+                if (latestLocation != null) {
+                    point = GpsPoint.builder()
+                            .latitude(latestLocation.getLatitude())
+                            .longitude(latestLocation.getLongitude())
+                            .timestamp(currentTime)
+                            .build();
+                    latest = point;
+
+                    log.info("최신 위치 정보 사용: {}", point);
+
+                } else {
+                    point = GpsPoint.builder()
+                            .latitude(0.0)
+                            .longitude(0.0)
+                            .timestamp(currentTime)
+                            .build();
+                    latest = point;
+
+                    log.info("기본 값 사용 (0.0, 0.0): {}", point);
+                }
+            }
+
+            result.add(point);
+        }
+
+        return result;
+    }
+
+}

--- a/rest/src/main/java/com/wherecar/rest/websocket/LocationBroadcaster.java
+++ b/rest/src/main/java/com/wherecar/rest/websocket/LocationBroadcaster.java
@@ -1,0 +1,20 @@
+package com.wherecar.rest.websocket;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class LocationBroadcaster {
+
+    private final CarLocationSocketHandler handler;
+
+    @Scheduled(cron = "0 * * * * *") //정분마다 실행
+    public void broadcast() {
+        log.info("LocationBroadcaster.broadcast() 호출됨 - 위치 업데이트 전송 시도");
+        handler.sendLocationUpdates();
+    }
+}

--- a/rest/src/main/java/com/wherecar/rest/websocket/config/WebSocketConfig.java
+++ b/rest/src/main/java/com/wherecar/rest/websocket/config/WebSocketConfig.java
@@ -1,0 +1,24 @@
+package com.wherecar.rest.websocket.config;
+
+import com.wherecar.rest.websocket.CarLocationSocketHandler;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.socket.config.annotation.EnableWebSocket;
+import org.springframework.web.socket.config.annotation.WebSocketConfigurer;
+import org.springframework.web.socket.config.annotation.WebSocketHandlerRegistry;
+
+@Configuration
+@EnableWebSocket
+@RequiredArgsConstructor
+@Slf4j
+public class WebSocketConfig implements WebSocketConfigurer {
+
+    private final CarLocationSocketHandler carLocationSocketHandler; // 스프링이 자동 주입
+
+    @Override
+    public void registerWebSocketHandlers(WebSocketHandlerRegistry registry) {
+        registry.addHandler(carLocationSocketHandler, "/ws") // 스프링 빈 사용!
+                .setAllowedOrigins("*");
+    }
+}


### PR DESCRIPTION
close #122


## 📝 작업 내용
> Spring Boot 기반의 WebSocket 서버를 구축하고, 차량 실시간 위치 데이터를 전송하는 기능을 구현했습니다.

- /ws/location 엔드포인트로 클라이언트가 연결하면, 해당 기업의 차량 위치를 실시간으로 전송합니다.

- Spring Scheduler를 활용해 매 정분마다 서버에서 1분치(60개)의 GPS 데이터를 일괄 전송합니다.

- 데이터 전송 시 클라이언트가 위치 공백 없이 처리할 수 있도록, fillTo60() 로직을 통해 최근 위치 기준으로 보간 처리를 적용했습니다.

##📍 기타 (선택)

프론트엔드에서는 WebSocket 수신 시 메시지 포맷(JSON)과 차량 ID 매핑 구조를 참고해 주세요.

향후 인증 처리 및 메시지 전송 최적화(예: 차량별 분리 전송 등)도 고려될 수 있습니다.