### PR TITLE
[#177] fix: 잘못된 경로 수정 및 메서드 인자 순서 수정

### DIFF
--- a/rest/src/main/java/com/wherecar/rest/geoinfo/presentation/GeoInfoController.java
+++ b/rest/src/main/java/com/wherecar/rest/geoinfo/presentation/GeoInfoController.java
@@ -22,7 +22,7 @@ public class GeoInfoController {
 
     public ResponseEntity<Void> geoInfoCreate(HttpServletRequest request, @RequestBody GeoInfoRequest geoInfoRequest) {
         Long companyId = (Long)request.getAttribute("companyId");
-        geoInfoService.createGeoInfo(geoInfoRequest, companyId);
+        geoInfoService.createGeoInfo(companyId, geoInfoRequest);
 
         return ResponseEntity.ok().build();
 

--- a/rest/src/main/java/com/wherecar/rest/geolog/application/GeoLogServiceImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/geolog/application/GeoLogServiceImpl.java
@@ -1,7 +1,7 @@
 package com.wherecar.rest.geolog.application;
 
 import com.wherecar.rest.car.domain.Car;
-import com.wherecar.rest.car.infrastructure.infra.CarReader;
+import com.wherecar.rest.car.infrastructure.CarReader;
 import com.wherecar.rest.geolog.application.dto.GeoLogRequest;
 import com.wherecar.rest.geolog.application.dto.GeoLogResponse;
 import com.wherecar.rest.geolog.domain.GeoLog;


### PR DESCRIPTION
close #177 

## 📝 작업 내용
> 잘못된 경로명과 메서드 인자 순서 수정
- 경로명 수정 : infra.CarReader -> CarReader
- geoInfoService.createGeoInfo(companyId, geoInfoRequest); 인자 위치 수정

두가지 이슈로 컴파일 에러가 발생해 수정했습니다. 


## 💬 리뷰 요구사항(선택)
geoInfoService.createGeoInfo 우선 에러가 안나게 위치 변경했는데 
작업하신 분께서는 맞는 작업인지 확인해주세요!

