### PR TITLE
[#183] feat: rest 다중 db 설정 및 통계 API 생성

### DIFF
--- a/rest/src/main/java/com/wherecar/rest/carlog/domain/constant/DriveType.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/domain/constant/DriveType.java
@@ -1,6 +1,8 @@
 package com.wherecar.rest.carlog.domain.constant;
 
 public enum DriveType {
+    UNCLASSIFIED,
     COMMUTE,
-    WORK
+    BUSINESS,
+    PERSONAL
 }

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/application/CarLogSummaryService.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/application/CarLogSummaryService.java
@@ -1,0 +1,10 @@
+package com.wherecar.rest.carlogsummary.application;
+
+import com.wherecar.rest.carlogsummary.application.dto.CarLogSummaryOverviewResponse;
+
+import java.time.LocalDateTime;
+
+public interface CarLogSummaryService {
+    CarLogSummaryOverviewResponse getCarLogSummaryOverviewByCompanyId(Long companyId, LocalDateTime from, LocalDateTime to);
+    CarLogSummaryOverviewResponse getCarLogSummaryOverviewByMdn(String mdn, LocalDateTime from, LocalDateTime to);
+}

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/application/CarLogSummaryServiceImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/application/CarLogSummaryServiceImpl.java
@@ -1,0 +1,34 @@
+package com.wherecar.rest.carlogsummary.application;
+
+import com.wherecar.rest.carlogsummary.application.dto.CarLogSummaryOverviewResponse;
+import com.wherecar.rest.carlogsummary.domain.CarLogSummary;
+import com.wherecar.rest.carlogsummary.domain.CarLogSummaryFactory;
+import com.wherecar.rest.carlogsummary.infrastructure.CarLogSummaryReader;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CarLogSummaryServiceImpl implements CarLogSummaryService {
+    private final CarLogSummaryReader carLogSummaryReader;
+    private final CarLogSummaryFactory carLogSummaryFactory;
+
+    @Override
+    public CarLogSummaryOverviewResponse getCarLogSummaryOverviewByCompanyId(Long companyId, LocalDateTime from, LocalDateTime to) {
+        List<CarLogSummary> carLogSummaries = carLogSummaryReader.getCarLogSummariesByCompanyIdAndOffTimeBetween(companyId, from, to);
+        return carLogSummaryFactory.toCarLogSummaryOverviewResponse(carLogSummaries);
+    }
+
+    @Override
+    public CarLogSummaryOverviewResponse getCarLogSummaryOverviewByMdn(String mdn, LocalDateTime from, LocalDateTime to) {
+        List<CarLogSummary> carLogSummaries = carLogSummaryReader.getCarLogSummariesByMdnAndOffTimeBetween(mdn, from, to);
+        return carLogSummaryFactory.toCarLogSummaryOverviewResponse(carLogSummaries);
+    }
+}

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/application/dto/CarLogSummaryOverviewResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/application/dto/CarLogSummaryOverviewResponse.java
@@ -1,0 +1,39 @@
+package com.wherecar.rest.carlogsummary.application.dto;
+
+import com.wherecar.rest.gpslog.application.dto.GpsPoint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CarLogSummaryOverviewResponse {
+    private Integer totalDistance;
+    private Integer maxDistance;
+    private Integer averageDistance;
+
+    private Integer maxSpeed;
+    private Integer averageSpeed;
+
+    //주행시간관련
+    private Integer totalDriveTime;
+    private Integer maxDriveTime;
+    private Integer averageDriveTime;
+
+    //driveType 갯수 확인
+    private Integer unclassifiedCount;
+    private Integer commuteCount;
+    private Integer businessCount;
+    private Integer personalCount;
+
+
+
+    //시동 on, off 정보
+    private List<GpsPoint> onList;
+    private List<GpsPoint> offList;
+}

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/domain/CarLogSummary.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/domain/CarLogSummary.java
@@ -1,0 +1,51 @@
+package com.wherecar.rest.carlogsummary.domain;
+
+
+import com.wherecar.rest.carlog.domain.constant.DriveType;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@Table(name = "car_log_summaries")
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CarLogSummary {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "car_log_summary_id")
+    private Long id;
+
+    @Column(name = "company_id")
+    private Long companyId;
+
+    private String mdn;
+    //    (km)
+    private Integer distance;
+    //    (km/h)
+    private Integer maxSpeed;
+    private Integer averageSpeed;
+
+    @Enumerated(EnumType.STRING)
+    private DriveType driveType;
+
+    private LocalDateTime onTime;
+    private Double onLatitude;
+    private Double onLongitude;
+
+    private LocalDateTime offTime;
+    private Double offLatitude;
+    private Double offLongitude;
+
+
+
+
+
+
+}

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/domain/CarLogSummaryFactory.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/domain/CarLogSummaryFactory.java
@@ -1,0 +1,90 @@
+package com.wherecar.rest.carlogsummary.domain;
+
+import com.wherecar.rest.carlogsummary.application.dto.CarLogSummaryOverviewResponse;
+import com.wherecar.rest.gpslog.application.dto.GpsPoint;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+public class CarLogSummaryFactory {
+    public CarLogSummaryOverviewResponse toCarLogSummaryOverviewResponse(List<CarLogSummary> carLogSummaries) {
+        int totalDistance = 0;
+        int maxDistance = 0;
+        int averageDistance;
+
+        int maxSpeed = 0;
+        int averageSpeed;
+
+        int totalDriveTime = 0;
+        int maxDriveTime = 0;
+        int averageDriveTime;
+
+        int unclassifiedCount = 0;
+        int commuteCount = 0;
+        int businessCount = 0;
+        int personalCount = 0;
+
+        List<GpsPoint> onList = new ArrayList<>();
+        List<GpsPoint> offList = new ArrayList<>();
+
+        for(CarLogSummary carLogSummary : carLogSummaries) {
+            maxDistance = Math.max(maxDistance, carLogSummary.getDistance());
+            maxSpeed = Math.max(maxSpeed, carLogSummary.getDistance());
+            maxDriveTime = Math.max(maxDriveTime,(int) Duration.between(carLogSummary.getOffTime(),carLogSummary.getOnTime()).toSeconds());
+
+            totalDistance += carLogSummary.getDistance();
+            totalDriveTime += (int) Duration.between(carLogSummary.getOffTime(),carLogSummary.getOnTime()).toSeconds();
+
+            switch (carLogSummary.getDriveType()) {
+                case UNCLASSIFIED -> unclassifiedCount++;
+                case PERSONAL     -> personalCount++;
+                case COMMUTE      -> commuteCount++;
+                case BUSINESS     -> businessCount++;
+            }
+
+
+            onList.add(GpsPoint.builder()
+                            .latitude(carLogSummary.getOnLatitude())
+                            .longitude(carLogSummary.getOnLongitude())
+                            .timestamp(carLogSummary.getOnTime())
+                    .build()
+            );
+
+            offList.add(GpsPoint.builder()
+                    .latitude(carLogSummary.getOffLatitude())
+                    .longitude(carLogSummary.getOffLongitude())
+                    .timestamp(carLogSummary.getOffTime())
+                    .build()
+            );
+        }
+
+        averageDistance = totalDistance / carLogSummaries.size();
+        averageSpeed = (totalDistance * 3600) / totalDriveTime;
+        averageDriveTime = totalDriveTime / carLogSummaries.size();
+
+
+
+
+        return CarLogSummaryOverviewResponse.builder()
+                .totalDistance(totalDistance)
+                .maxDistance(maxDistance)
+                .averageDistance(averageDistance)
+                .maxSpeed(maxSpeed)
+                .averageSpeed(averageSpeed)
+                .totalDriveTime(totalDriveTime)
+                .maxDriveTime(maxDriveTime)
+                .averageDriveTime(averageDriveTime)
+                .unclassifiedCount(unclassifiedCount)
+                .commuteCount(commuteCount)
+                .businessCount(businessCount)
+                .personalCount(personalCount)
+                .onList(onList)
+                .offList(offList)
+                .build();
+    }
+}

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/domain/CarLogSummaryFactory.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/domain/CarLogSummaryFactory.java
@@ -34,11 +34,11 @@ public class CarLogSummaryFactory {
 
         for(CarLogSummary carLogSummary : carLogSummaries) {
             maxDistance = Math.max(maxDistance, carLogSummary.getDistance());
-            maxSpeed = Math.max(maxSpeed, carLogSummary.getDistance());
-            maxDriveTime = Math.max(maxDriveTime,(int) Duration.between(carLogSummary.getOffTime(),carLogSummary.getOnTime()).toSeconds());
+            maxSpeed = Math.max(maxSpeed, carLogSummary.getMaxSpeed());
+            maxDriveTime = Math.max(maxDriveTime, (int) Duration.between(carLogSummary.getOnTime(),carLogSummary.getOffTime()).toSeconds());
 
             totalDistance += carLogSummary.getDistance();
-            totalDriveTime += (int) Duration.between(carLogSummary.getOffTime(),carLogSummary.getOnTime()).toSeconds();
+            totalDriveTime += (int) Duration.between(carLogSummary.getOnTime(),carLogSummary.getOffTime()).toSeconds();
 
             switch (carLogSummary.getDriveType()) {
                 case UNCLASSIFIED -> unclassifiedCount++;

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/infrastructure/CarLogSummaryReader.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/infrastructure/CarLogSummaryReader.java
@@ -1,0 +1,11 @@
+package com.wherecar.rest.carlogsummary.infrastructure;
+
+import com.wherecar.rest.carlogsummary.domain.CarLogSummary;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CarLogSummaryReader {
+    List<CarLogSummary> getCarLogSummariesByCompanyIdAndOffTimeBetween(Long companyId, LocalDateTime from, LocalDateTime to);
+    List<CarLogSummary> getCarLogSummariesByMdnAndOffTimeBetween(String mdn, LocalDateTime from, LocalDateTime to);
+}

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/infrastructure/CarLogSummaryReaderImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/infrastructure/CarLogSummaryReaderImpl.java
@@ -1,0 +1,27 @@
+package com.wherecar.rest.carlogsummary.infrastructure;
+
+import com.wherecar.rest.carlogsummary.domain.CarLogSummary;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CarLogSummaryReaderImpl implements CarLogSummaryReader {
+
+    private final CarLogSummaryRepository carLogSummaryRepository;
+
+    @Override
+    public List<CarLogSummary> getCarLogSummariesByCompanyIdAndOffTimeBetween(Long companyId, LocalDateTime from, LocalDateTime to) {
+        return carLogSummaryRepository.findByCompanyIdAndOffTimeBetween(companyId, from, to);
+    }
+
+    @Override
+    public List<CarLogSummary> getCarLogSummariesByMdnAndOffTimeBetween(String mdn, LocalDateTime from, LocalDateTime to) {
+        return carLogSummaryRepository.findByMdnAndOffTimeBetween(mdn, from, to);
+    }
+}

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/infrastructure/CarLogSummaryRepository.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/infrastructure/CarLogSummaryRepository.java
@@ -1,0 +1,12 @@
+package com.wherecar.rest.carlogsummary.infrastructure;
+
+import com.wherecar.rest.carlogsummary.domain.CarLogSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface CarLogSummaryRepository extends JpaRepository<CarLogSummary, Long> {
+    List<CarLogSummary> findByCompanyIdAndOffTimeBetween(Long companyId, LocalDateTime from, LocalDateTime to);
+    List<CarLogSummary> findByMdnAndOffTimeBetween(String mdn, LocalDateTime from, LocalDateTime to);
+}

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/presentation/CarLogSummaryController.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/presentation/CarLogSummaryController.java
@@ -1,0 +1,49 @@
+package com.wherecar.rest.carlogsummary.presentation;
+
+import com.wherecar.rest.carlogsummary.application.CarLogSummaryService;
+import com.wherecar.rest.carlogsummary.application.dto.CarLogSummaryOverviewResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/stat")
+@RequiredArgsConstructor
+public class CarLogSummaryController {
+    private final CarLogSummaryService carLogSummaryService;
+
+    @GetMapping("/companies/my")
+    public ResponseEntity<CarLogSummaryOverviewResponse> carLogSummaryOverviewGetByCompanyId(HttpServletRequest request, @RequestParam String from, @RequestParam String to) {
+        Long companyId = (Long)request.getAttribute("companyId");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        LocalDateTime fromDateTime = LocalDate.parse(from, formatter).atStartOfDay();
+        LocalDateTime toDateTime = LocalDate.parse(to, formatter).atTime(23, 59, 59);
+
+        CarLogSummaryOverviewResponse overviewResponse =
+                carLogSummaryService.getCarLogSummaryOverviewByCompanyId(companyId, fromDateTime, toDateTime);
+
+        return ResponseEntity.ok(overviewResponse);
+    }
+
+    @GetMapping("/mdn")
+    public ResponseEntity<CarLogSummaryOverviewResponse> carLogSummaryOverviewGetByMdn(@RequestParam String mdn, @RequestParam String from, @RequestParam String to) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+        LocalDateTime fromDateTime = LocalDate.parse(from, formatter).atStartOfDay();
+        LocalDateTime toDateTime = LocalDate.parse(to, formatter).atTime(23, 59, 59);
+
+        CarLogSummaryOverviewResponse overviewResponse = carLogSummaryService.getCarLogSummaryOverviewByMdn(mdn, fromDateTime, toDateTime);
+        return ResponseEntity.ok(overviewResponse);
+    }
+}

--- a/rest/src/main/java/com/wherecar/rest/common/config/MainDataSourceConfig.java
+++ b/rest/src/main/java/com/wherecar/rest/common/config/MainDataSourceConfig.java
@@ -1,0 +1,78 @@
+package com.wherecar.rest.common.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.*;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+        basePackages = {
+                "com.wherecar.rest.user",
+                "com.wherecar.rest.car",
+                "com.wherecar.rest.carlog",
+                "com.wherecar.rest.geoinfo",
+                "com.wherecar.rest.geolog",
+                "com.wherecar.rest.gpslog",
+                "com.wherecar.rest.company",
+                "com.wherecar.rest.announcement",
+                "com.wherecar.rest.security",
+                "com.wherecar.rest.websocket",
+                "com.wherecar.rest.common"
+        },
+        entityManagerFactoryRef = "mainEntityManagerFactory",
+        transactionManagerRef = "mainTransactionManager"
+)
+public class MainDataSourceConfig {
+
+    @Primary
+    @Bean(name = "mainDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.maindb")
+    public DataSource mainDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Primary
+    @Bean(name = "mainEntityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean mainEntityManagerFactory(
+            EntityManagerFactoryBuilder builder,
+            @Qualifier("mainDataSource") DataSource dataSource) {
+
+        return builder
+                .dataSource(dataSource)
+                .packages(
+                        "com.wherecar.rest.user",
+                        "com.wherecar.rest.car",
+                        "com.wherecar.rest.carlog",
+                        "com.wherecar.rest.geoinfo",
+                        "com.wherecar.rest.geolog",
+                        "com.wherecar.rest.gpslog",
+                        "com.wherecar.rest.company",
+                        "com.wherecar.rest.announcement",
+                        "com.wherecar.rest.security",
+                        "com.wherecar.rest.websocket",
+                        "com.wherecar.rest.common"
+                ) // carlogsummary 만 제외
+                .persistenceUnit("main")
+                .build();
+    }
+
+    @Primary
+    @Bean(name = "mainTransactionManager")
+    public PlatformTransactionManager mainTransactionManager(
+            @Qualifier("mainEntityManagerFactory") EntityManagerFactory entityManagerFactory) {
+
+        return new JpaTransactionManager(entityManagerFactory);
+    }
+}
+

--- a/rest/src/main/java/com/wherecar/rest/common/config/StatDataSourceConfig.java
+++ b/rest/src/main/java/com/wherecar/rest/common/config/StatDataSourceConfig.java
@@ -1,0 +1,51 @@
+package com.wherecar.rest.common.config;
+
+import jakarta.persistence.EntityManagerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.boot.orm.jpa.EntityManagerFactoryBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.orm.jpa.JpaTransactionManager;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
+
+import javax.sql.DataSource;
+
+@Configuration
+@EnableTransactionManagement
+@EnableJpaRepositories(
+        basePackages = "com.wherecar.rest.carlogsummary",
+        entityManagerFactoryRef = "statEntityManagerFactory",
+        transactionManagerRef = "statTransactionManager"
+)
+public class StatDataSourceConfig {
+
+    @Bean(name = "statDataSource")
+    @ConfigurationProperties(prefix = "spring.datasource.statdb")
+    public DataSource statDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean(name = "statEntityManagerFactory")
+    public LocalContainerEntityManagerFactoryBean statEntityManagerFactory(
+            EntityManagerFactoryBuilder builder,
+            @Qualifier("statDataSource") DataSource dataSource) {
+
+        return builder
+                .dataSource(dataSource)
+                .packages("com.wherecar.rest.carlogsummary")
+                .persistenceUnit("stat")
+                .build();
+    }
+
+    @Bean(name = "statTransactionManager")
+    public PlatformTransactionManager statTransactionManager(
+            @Qualifier("statEntityManagerFactory") EntityManagerFactory entityManagerFactory) {
+
+        return new JpaTransactionManager(entityManagerFactory);
+    }
+}

--- a/rest/src/main/resources/application-dev.yml
+++ b/rest/src/main/resources/application-dev.yml
@@ -1,16 +1,27 @@
 spring:
   config:
     activate:
-      on-profile: dev # 'dev' 프로파일이 활성화될 때 이 설정을 사용합니다.
+      on-profile: dev
   jpa:
     hibernate:
       ddl-auto: update
+
   datasource:
-    url: jdbc:mysql://${DB_HOST_NAME}/${DB_STORAGE_NAME}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+    maindb:
+      jdbc-url: jdbc:mysql://${MAIN_DB_HOST_NAME}/${MAIN_DB_STORAGE_NAME}
+      username: ${MAIN_DB_USERNAME}
+      password: ${MAIN_DB_PASSWORD}
+      driver-class-name: com.mysql.cj.jdbc.Driver
+
+    statdb:
+      jdbc-url: jdbc:mysql://${STAT_DB_HOST_NAME}/${STAT_DB_STORAGE_NAME}
+      username: ${STAT_DB_USERNAME}
+      password: ${STAT_DB_PASSWORD}
+      driver-class-name: com.mysql.cj.jdbc.Driver
+
   jwt:
-    secret: 1o23eoi21joiejoijsdoijoisdjfojafa # JWT 비밀 키
+    secret: 1o23eoi21joiejoijsdoijoisdjfojafa
 
 server:
   port: 8080
+

--- a/rest/src/main/resources/application-prod.yml
+++ b/rest/src/main/resources/application-prod.yml
@@ -5,10 +5,17 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-  datasource:
-    url: jdbc:mysql://${DB_HOST_NAME}/${DB_STORAGE_NAME}
-    username: ${DB_USERNAME}
-    password: ${DB_PASSWORD}
+  datasource-main:
+    jdbc-url: jdbc:mysql://${MAIN_DB_HOST_NAME}/${MAIN_DB_STORAGE_NAME}
+    username: ${MAIN_DB_USERNAME}
+    password: ${MAIN_DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+  datasource-stat:
+    jdbc-url: jdbc:mysql://${STAT_DB_HOST_NAME}/${STAT_DB_STORAGE_NAME}
+    username: ${STAT_DB_USERNAME}
+    password: ${STAT_DB_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jwt:
     secret: 1o23eoi21joiejoijsdoijoisdjfojafa # JWT 비밀 키
 

--- a/rest/src/main/resources/sql/car_log_summaries.sql
+++ b/rest/src/main/resources/sql/car_log_summaries.sql
@@ -1,0 +1,14 @@
+INSERT INTO car_log_summaries (company_id, mdn, distance, max_speed, average_speed, drive_type, on_time, on_latitude, on_longitude, off_time, off_latitude, off_longitude)
+VALUES (1, '01012345678', 120, 95, 60, 'BUSINESS', '2025-04-20 08:00:00', 37.5665, 126.9780, '2025-04-20 08:45:00', 37.5700, 126.9900);
+
+INSERT INTO car_log_summaries (company_id, mdn, distance, max_speed, average_speed, drive_type, on_time, on_latitude, on_longitude, off_time, off_latitude, off_longitude)
+VALUES (1, '01087654321', 80, 85, 55, 'PERSONAL', '2025-04-20 09:10:00', 37.5510, 126.9880, '2025-04-20 09:55:00', 37.5600, 126.9960);
+
+INSERT INTO car_log_summaries (company_id, mdn, distance, max_speed, average_speed, drive_type, on_time, on_latitude, on_longitude, off_time, off_latitude, off_longitude)
+VALUES (1, '01011223344', 200, 110, 70, 'BUSINESS', '2025-04-20 10:30:00', 37.5800, 126.9760, '2025-04-20 12:00:00', 37.6000, 127.0000);
+
+INSERT INTO car_log_summaries (company_id, mdn, distance, max_speed, average_speed, drive_type, on_time, on_latitude, on_longitude, off_time, off_latitude, off_longitude)
+VALUES (1, '01044332211', 50, 60, 40, 'COMMUTE', '2025-04-20 13:20:00', 37.5400, 126.9700, '2025-04-20 13:50:00', 37.5450, 126.9750);
+
+INSERT INTO car_log_summaries (company_id, mdn, distance, max_speed, average_speed, drive_type, on_time, on_latitude, on_longitude, off_time, off_latitude, off_longitude)
+VALUES (1, '01055667788', 150, 100, 65, 'BUSINESS', '2025-04-20 14:15:00', 37.5100, 127.0000, '2025-04-20 15:30:00', 37.5300, 127.0200);


### PR DESCRIPTION
close #183

## 📝 작업 내용

## ✅ 주요 변경 사항  

### 1. 다중 DB 설정 (`main`, `stat`)
- `MainDataSourceConfig`, `StatDataSourceConfig` 클래스 추가
- `main` → 대부분 도메인  
- `stat` → 통계 전용(`CarLogSummary`)

### 2. 통계 도메인 추가
- `CarLogSummary` Entity 생성
- `CarLogSummaryReader`, `Factory`, `Repository` 구성
- 통계 DTO: `CarLogSummaryOverviewResponse` 생성

### 3. 통계 API 생성
- **[GET] `/api/stat/companies/my`**  
  - 내 회사 통계 조회 (회사 ID는 Request Attribute로 처리)
- **[GET] `/api/stat/mdn`**  
  - 특정 단말 기준 통계 조회

---

## 📊 통계 항목

- 총/최대/평균 주행 거리
- 최대/평균 속도
- 총/최대/평균 운행 시간
- 운행 목적별 개수 (미분류, 출퇴근, 업무, 개인)
- 시동 ON/OFF 위치 좌표 리스트

---

## 🧪 기타
- `application-dev.yml`, `application-prod.yml` 내 다중 DB 설정 추가
- 통계 데이터는 `stat` DB에서 조회
- `companyId`는 `HttpServletRequest`에서 추출



# 📍 기타 (선택)

> 환경변수:  MAIN_DB_HOST_NAME=localhost:3308;MAIN_DB_STORAGE_NAME=wherecar;MAIN_DB_USERNAME=user;MAIN_DB_PASSWORD=1234;STAT_DB_HOST_NAME=localhost:3309;STAT_DB_STORAGE_NAME=stat;STAT_DB_USERNAME=user;STAT_DB_PASSWORD=1234;KEY_STORE_PASSWORD=wherecar@#0407;TRUST_STORE_PASSWORD=wherecar@#0407
