### PR TITLE
[#180] modify: Collector 비동기 전환

### DIFF
--- a/collector/src/main/java/com/wherecar/collector/CollectorApplication.java
+++ b/collector/src/main/java/com/wherecar/collector/CollectorApplication.java
@@ -2,8 +2,10 @@ package com.wherecar.collector;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+@EnableJpaAuditing
 @EnableTransactionManagement
 @SpringBootApplication
 public class CollectorApplication {

--- a/collector/src/main/java/com/wherecar/collector/CollectorApplication.java
+++ b/collector/src/main/java/com/wherecar/collector/CollectorApplication.java
@@ -2,7 +2,9 @@ package com.wherecar.collector;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
+@EnableTransactionManagement
 @SpringBootApplication
 public class CollectorApplication {
 

--- a/collector/src/main/java/com/wherecar/collector/car/domain/CarStatus.java
+++ b/collector/src/main/java/com/wherecar/collector/car/domain/CarStatus.java
@@ -12,7 +12,7 @@ import lombok.*;
 @ToString(exclude = "car")
 @NoArgsConstructor
 @AllArgsConstructor
-public class CarStatus  extends BaseEntity {
+public class CarStatus extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/collector/src/main/java/com/wherecar/collector/car/infrastructure/CarStatusRepository.java
+++ b/collector/src/main/java/com/wherecar/collector/car/infrastructure/CarStatusRepository.java
@@ -1,10 +1,33 @@
 package com.wherecar.collector.car.infrastructure;
 
 import com.wherecar.collector.car.domain.CarStatus;
+import com.wherecar.collector.common.constant.CarState;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface CarStatusRepository extends JpaRepository<CarStatus, Long> {
     Optional<CarStatus> findByCarId(Long carId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT cs FROM CarStatus cs WHERE cs.car.id = :carId")
+    Optional<CarStatus> findByCarIdForUpdate(@Param("carId") Long carId);
+
+    @Modifying
+    @Query("UPDATE CarStatus cs SET cs.batteryVoltage = :batteryVoltage WHERE cs.car.id = :carId")
+    void updateBatteryVoltage(@Param("carId") Long carId, @Param("batteryVoltage") Integer batteryVoltage);
+
+    @Modifying
+    @Query("UPDATE CarStatus cs SET cs.mileage = :mileage WHERE cs.car.id = :carId")
+    void updateMileage(@Param("carId") Long carId, @Param("mileage") Double mileage);
+
+
+    @Modifying
+    @Query("UPDATE CarStatus cs SET cs.carState = :carState WHERE cs.car.id = :carId")
+    void updateCarState(@Param("carId") Long carId, @Param("carState") CarState carState);
 }

--- a/collector/src/main/java/com/wherecar/collector/carlog/domain/CarLogFactory.java
+++ b/collector/src/main/java/com/wherecar/collector/carlog/domain/CarLogFactory.java
@@ -53,7 +53,6 @@ public class CarLogFactory {
                 .onMileage(onMileage)
                 .onTime(onTime)
                 .build();
-
     }
     
     public CarLog toOffLog(CarLogRequest carLogRequest, CarLog previousCarLog) {

--- a/collector/src/main/java/com/wherecar/collector/carlog/infrastructure/CarLogStoreImpl.java
+++ b/collector/src/main/java/com/wherecar/collector/carlog/infrastructure/CarLogStoreImpl.java
@@ -23,10 +23,15 @@ public class CarLogStoreImpl implements CarLogStore {
 
         carLogRepository.save(carLog);
 
-        CarStatus carStatus = carStatusRepository.findByCarId(car.getId()).orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
-        carStatus.changeMileage(0.0); // 최초 출고일 땐 mileage가 0.0
-        carStatus.changeCarState(CarState.RUNNING);
-        carStatusRepository.save(carStatus);
+//        CarStatus carStatus = carStatusRepository.findByCarId(car.getId()).orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
+//        CarStatus carStatus = carStatusRepository.findByCarIdForUpdate(car.getId())
+//                .orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
+//        carStatus.changeMileage(0.0); // 최초 출고일 땐 mileage가 0.0
+//        carStatus.changeCarState(CarState.RUNNING);
+//        carStatusRepository.save(carStatus);
+
+        carStatusRepository.updateMileage(car.getId(), 0.0);
+        carStatusRepository.updateCarState(car.getId(), CarState.RUNNING);
     }
 
     @Override
@@ -39,9 +44,12 @@ public class CarLogStoreImpl implements CarLogStore {
         } else { // 시동 ON 시 최초 누적 거리 == 직전 시동 OFF일 때의 누적 거리
             carLogRepository.save(carLog);
 
-            CarStatus carStatus = carStatusRepository.findByCarId(car.getId()).orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
-            carStatus.changeCarState(CarState.RUNNING);
-            carStatusRepository.save(carStatus);
+//            CarStatus carStatus = carStatusRepository.findByCarId(car.getId()).orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
+//            CarStatus carStatus = carStatusRepository.findByCarIdForUpdate(car.getId())
+//                    .orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
+//            carStatus.changeCarState(CarState.RUNNING);
+//            carStatusRepository.save(carStatus);
+            carStatusRepository.updateCarState(car.getId(), CarState.RUNNING);
         }
     }
 
@@ -53,10 +61,15 @@ public class CarLogStoreImpl implements CarLogStore {
         Integer sumToAdd = CarLog.getSumToAdd(previousCarLog.getOnSum(), Integer.parseInt(offLogRequest.getSum()));
         Double offMileage = CarLog.getOffMileage(previousCarLog.getOnMileage(), sumToAdd);
 
-        CarStatus carStatus = carStatusRepository.findByCarId(car.getId()).orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
-        carStatus.changeMileage(offMileage);
-        carStatus.changeCarState(CarState.STOPPED);
-        carStatusRepository.save(carStatus);
+//        CarStatus carStatus = carStatusRepository.findByCarId(car.getId()).orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
+//        CarStatus carStatus = carStatusRepository.findByCarIdForUpdate(car.getId())
+//                .orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
+//        carStatus.changeMileage(offMileage);
+//        carStatus.changeCarState(CarState.STOPPED);
+//        carStatusRepository.save(carStatus);
+
+        carStatusRepository.updateMileage(car.getId(), offMileage);
+        carStatusRepository.updateCarState(car.getId(), CarState.STOPPED);
     }
 
 }

--- a/collector/src/main/java/com/wherecar/collector/common/config/AsyncConfig.java
+++ b/collector/src/main/java/com/wherecar/collector/common/config/AsyncConfig.java
@@ -1,0 +1,27 @@
+package com.wherecar.collector.common.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+
+import java.lang.reflect.Method;
+
+@Slf4j
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
+        return new AsyncUncaughtExceptionHandler() {
+
+            @Override
+            public void handleUncaughtException(Throwable ex, Method method, Object... params) {
+                log.error("비동기 메서드에서 예외 발생: method={}, message={}", method.getName(), ex.getMessage(), ex);
+            }
+        };
+    }
+
+}

--- a/collector/src/main/java/com/wherecar/collector/gpslog/application/GpsLogServiceImpl.java
+++ b/collector/src/main/java/com/wherecar/collector/gpslog/application/GpsLogServiceImpl.java
@@ -34,7 +34,7 @@ public class GpsLogServiceImpl implements GpsLogService {
                     .map(GpsLogInfo::getBat)
                     .toList();
             List<GpsLog> gpsLogList = gpsLogFactory.toGpsLogList(gpsLogRequest);
-            gpsLogStore.storeGpsLogs(gpsLogList, car, batList);
+            gpsLogStore.store(gpsLogList, car, batList);
         } catch (Exception e) {
             log.error("GPS 로그 저장 비동기 처리 예외 발생", e);
         }

--- a/collector/src/main/java/com/wherecar/collector/gpslog/application/GpsLogServiceImpl.java
+++ b/collector/src/main/java/com/wherecar/collector/gpslog/application/GpsLogServiceImpl.java
@@ -56,8 +56,10 @@ public class GpsLogServiceImpl implements GpsLogService {
 //    public void receiveGpsLogs(GpsLogRequest gpsLogRequest) {
 //
 //        Car car = carReader.getCarByMdn(gpsLogRequest.getMdn());
-//        String bat = gpsLogRequest.getCList().get(0).getBat();
+//        List<String> batList = gpsLogRequest.getCList().stream()
+//                .map(GpsLogInfo::getBat)
+//                .toList();
 //        List<GpsLog> gpsLogList = gpsLogFactory.toGpsLogList(gpsLogRequest);
-//        gpsLogStore.storeGpsLogs(gpsLogList, car, bat);
+//        gpsLogStore.storeGpsLogs(gpsLogList, car, batList);
 //    }
 //}

--- a/collector/src/main/java/com/wherecar/collector/gpslog/application/GpsLogServiceImpl.java
+++ b/collector/src/main/java/com/wherecar/collector/gpslog/application/GpsLogServiceImpl.java
@@ -1,6 +1,7 @@
 package com.wherecar.collector.gpslog.application;
 
 import com.wherecar.collector.car.domain.Car;
+import com.wherecar.collector.gpslog.application.dto.GpsLogInfo;
 import com.wherecar.collector.gpslog.application.dto.GpsLogRequest;
 import com.wherecar.collector.gpslog.domain.GpsLog;
 import com.wherecar.collector.gpslog.domain.GpsLogFactory;
@@ -8,15 +9,16 @@ import com.wherecar.collector.car.infrastructure.CarReader;
 import com.wherecar.collector.gpslog.infrastructure.GpsLogStore;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
 @RequiredArgsConstructor
-@Transactional
 public class GpsLogServiceImpl implements GpsLogService {
 
     private final CarReader carReader;
@@ -24,11 +26,38 @@ public class GpsLogServiceImpl implements GpsLogService {
     private final GpsLogFactory gpsLogFactory;
 
     @Override
+    @Async
     public void receiveGpsLogs(GpsLogRequest gpsLogRequest) {
-
-        Car car = carReader.getCarByMdn(gpsLogRequest.getMdn());
-        String bat = gpsLogRequest.getCList().get(0).getBat();
-        List<GpsLog> gpsLogList = gpsLogFactory.toGpsLogList(gpsLogRequest);
-        gpsLogStore.storeGpsLogs(gpsLogList, car, bat);
+        try {
+            Car car = carReader.getCarByMdn(gpsLogRequest.getMdn());
+            List<String> batList = gpsLogRequest.getCList().stream()
+                    .map(GpsLogInfo::getBat)
+                    .toList();
+            List<GpsLog> gpsLogList = gpsLogFactory.toGpsLogList(gpsLogRequest);
+            gpsLogStore.storeGpsLogs(gpsLogList, car, batList);
+        } catch (Exception e) {
+            log.error("GPS 로그 저장 비동기 처리 예외 발생", e);
+        }
     }
 }
+
+
+//@Slf4j
+//@Service
+//@RequiredArgsConstructor
+//@Transactional
+//public class GpsLogServiceImpl implements GpsLogService {
+//
+//    private final CarReader carReader;
+//    private final GpsLogStore gpsLogStore;
+//    private final GpsLogFactory gpsLogFactory;
+//
+//    @Override
+//    public void receiveGpsLogs(GpsLogRequest gpsLogRequest) {
+//
+//        Car car = carReader.getCarByMdn(gpsLogRequest.getMdn());
+//        String bat = gpsLogRequest.getCList().get(0).getBat();
+//        List<GpsLog> gpsLogList = gpsLogFactory.toGpsLogList(gpsLogRequest);
+//        gpsLogStore.storeGpsLogs(gpsLogList, car, bat);
+//    }
+//}

--- a/collector/src/main/java/com/wherecar/collector/gpslog/infrastructure/GpsLogStore.java
+++ b/collector/src/main/java/com/wherecar/collector/gpslog/infrastructure/GpsLogStore.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface GpsLogStore {
 
-    void storeGpsLogs(List<GpsLog> gpsLogList, Car car, List<String> batList);
+    void store(List<GpsLog> gpsLogList, Car car, List<String> batList);
 }

--- a/collector/src/main/java/com/wherecar/collector/gpslog/infrastructure/GpsLogStore.java
+++ b/collector/src/main/java/com/wherecar/collector/gpslog/infrastructure/GpsLogStore.java
@@ -7,5 +7,5 @@ import java.util.List;
 
 public interface GpsLogStore {
 
-    void storeGpsLogs(List<GpsLog> gpsLogList, Car car, String bat);
+    void storeGpsLogs(List<GpsLog> gpsLogList, Car car, List<String> batList);
 }

--- a/collector/src/main/java/com/wherecar/collector/gpslog/infrastructure/GpsLogStoreImpl.java
+++ b/collector/src/main/java/com/wherecar/collector/gpslog/infrastructure/GpsLogStoreImpl.java
@@ -7,6 +7,8 @@ import com.wherecar.collector.car.infrastructure.CarStatusRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 
 @Slf4j
@@ -18,22 +20,21 @@ public class GpsLogStoreImpl implements GpsLogStore {
     private final CarStatusRepository carStatusRepository;
 
     @Override
-    public void storeGpsLogs(List<GpsLog> gpsLogList, Car car, String bat) {
+    @Transactional
+    public void storeGpsLogs(List<GpsLog> gpsLogList, Car car, List<String> batList) {
 
-        boolean isFirst = true;
-
-        for (GpsLog gpsLog : gpsLogList) {
+        for (int i = 0; i < gpsLogList.size(); i++) {
+            GpsLog gpsLog = gpsLogList.get(i);
+            String bat = batList.get(i);
 
             gpsLogRepository.save(gpsLog);
 
-            if (isFirst) {
-                CarStatus carStatus = carStatusRepository.findByCarId(car.getId()).orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
-                carStatus.changeBatteryVoltage(Integer.parseInt(bat));
-                carStatusRepository.save(carStatus);
-
-                isFirst = false;
-            }
-
+//            CarStatus carStatus = carStatusRepository.findByCarId(car.getId()).orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
+//            CarStatus carStatus = carStatusRepository.findByCarIdForUpdate(car.getId())
+//                    .orElseThrow(() -> new RuntimeException("CarStatus가 없습니다."));
+//            carStatus.changeBatteryVoltage(Integer.parseInt(bat));
+//            carStatusRepository.save(carStatus);
+            carStatusRepository.updateBatteryVoltage(car.getId(), Integer.parseInt(bat));
         }
 
     }

--- a/collector/src/main/java/com/wherecar/collector/gpslog/infrastructure/GpsLogStoreImpl.java
+++ b/collector/src/main/java/com/wherecar/collector/gpslog/infrastructure/GpsLogStoreImpl.java
@@ -1,7 +1,6 @@
 package com.wherecar.collector.gpslog.infrastructure;
 
 import com.wherecar.collector.car.domain.Car;
-import com.wherecar.collector.car.domain.CarStatus;
 import com.wherecar.collector.gpslog.domain.GpsLog;
 import com.wherecar.collector.car.infrastructure.CarStatusRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +20,7 @@ public class GpsLogStoreImpl implements GpsLogStore {
 
     @Override
     @Transactional
-    public void storeGpsLogs(List<GpsLog> gpsLogList, Car car, List<String> batList) {
+    public void store(List<GpsLog> gpsLogList, Car car, List<String> batList) {
 
         for (int i = 0; i < gpsLogList.size(); i++) {
             GpsLog gpsLog = gpsLogList.get(i);


### PR DESCRIPTION
close #180

## 📝 작업 내용

1. Collector 엔터티들에 createdAt, updatedAt 적용했습니다.
2. CarStatusRepository에서 JPQL 쿼리를 직접 작성했습니다.
3. GpsLogServiceImpl에서 비동기 코드로 적용하고, 동기 코드는 주석 처리했습니다. CarLogServiceImpl은 여전히 동기 코드로 유지했습니다.
4. 배터리 전압을 CarStatus에 반영하는 로직이 기존엔 60초 데이터 리스트 중 첫 번째 데이터 작업 때만 반영했었지만, 이제는 매초마다 반영하도록 다시 복구했습니다.
5. 비동기 코드로 전환하면서 CarLog를 처리하는 코드와 GpsLog를 처리하는 코드에서 CarStatus에 동시에 접근하는 문제가 발생하여 해결했습니다.

아래는 로컬에서 수행한 부하 테스트 결과 사진입니다.

1) 동기 방식 1000개 쓰레드 부하 테스트 결과
<img width="944" alt="동기 1000개" src="https://github.com/user-attachments/assets/c0fdb55d-1cbe-4077-9758-52b7b70e49ce" />

2) 비동기 방식 1000개 쓰레드 부하 테스트 결과
<img width="948" alt="비동기 1000개" src="https://github.com/user-attachments/assets/806d03ff-9b28-4975-ac68-0c56caf722fa" />

3) 동기 방식 10000개 쓰레드 부하 테스트 결과
<img width="942" alt="동기 10000개" src="https://github.com/user-attachments/assets/7e565e07-8088-4685-a964-0c3d55ba33b0" />

4) 비동기 방식 10000개 쓰레드 부하 테스트 결과
<img width="845" alt="비동기 10000개" src="https://github.com/user-attachments/assets/7031cea0-8aef-431d-866f-3f4e138f778e" />