### PR TITLE
[#199] modify: 모든 컨트롤러 ResponseEntity<BaseResponse<T>> 로 리턴하도록 변경

### DIFF
--- a/rest/src/main/java/com/wherecar/rest/announcement/presentation/AnnouncementController.java
+++ b/rest/src/main/java/com/wherecar/rest/announcement/presentation/AnnouncementController.java
@@ -1,18 +1,18 @@
 package com.wherecar.rest.announcement.presentation;
 
+import com.wherecar.rest.announcement.application.AnnouncementService;
 import com.wherecar.rest.announcement.application.dto.AnnouncementRequest;
 import com.wherecar.rest.announcement.application.dto.AnnouncementResponse;
-import com.wherecar.rest.announcement.application.AnnouncementService;
 import com.wherecar.rest.common.constants.PaginationConstants;
+import com.wherecar.rest.common.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
-import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
 @RestController
-@RequestMapping("/api/announcement")
+@RequestMapping("/api/announcements")
 @RequiredArgsConstructor
 public class AnnouncementController {
 
@@ -20,45 +20,45 @@ public class AnnouncementController {
 
     // 공지 사항 등록
     @PostMapping
-    public ResponseEntity<Void> announcementCreate(@RequestBody AnnouncementRequest announcementRequest) {
-        announcementService.createAnnouncement(announcementRequest);
+    public BaseResponse<AnnouncementResponse> announcementCreate(@RequestBody AnnouncementRequest announcementRequest) {
+        AnnouncementResponse announcementResponse = announcementService.createAnnouncement(announcementRequest);
 
-        return ResponseEntity.ok().build();
+        return BaseResponse.created(announcementResponse);
     }
 
     // 공지 사항 목록 조회
     @GetMapping
-    public ResponseEntity<Page<AnnouncementResponse>> announcementsGet(
+    public BaseResponse<Page<AnnouncementResponse>> announcementsGet(
             @RequestParam(value = "page", defaultValue = "" + PaginationConstants.DEFAULT_PAGE) int page,
             @RequestParam(value = "size", defaultValue = "" + PaginationConstants.DEFAULT_SIZE) int size)
     {
         Page<AnnouncementResponse> announcements = announcementService.getAnnouncements(page, size);
 
-        return ResponseEntity.ok(announcements);
+        return BaseResponse.ok(announcements);
     }
 
     // 공지 사항 글 조회
     @GetMapping("/{announcementId}")
-    public ResponseEntity<AnnouncementResponse> announcementGetDetail(@PathVariable Long announcementId) {
+    public BaseResponse<AnnouncementResponse> announcementGetDetail(@PathVariable Long announcementId) {
         AnnouncementResponse announcement = announcementService.getAnnouncementDetail(announcementId);
 
-        return ResponseEntity.ok(announcement);
+        return BaseResponse.ok(announcement);
     }
 
     // 공지 사항 수정
     @PutMapping("/{announcementId}")
-    public ResponseEntity<Void> announcementUpdate(@PathVariable Long announcementId, @RequestBody AnnouncementRequest announcementRequest) {
-        announcementService.updateAnnouncement(announcementId, announcementRequest);
+    public BaseResponse<AnnouncementResponse> announcementUpdate(@PathVariable Long announcementId, @RequestBody AnnouncementRequest announcementRequest) {
+        AnnouncementResponse announcementResponse = announcementService.updateAnnouncement(announcementId, announcementRequest);
 
-        return ResponseEntity.ok().build();
+        return BaseResponse.created(announcementResponse);
     }
 
     // 공지 사항 삭제
     @DeleteMapping("/{announcementId}")
-    public ResponseEntity<Void> announcementDelete(@PathVariable Long announcementId) {
+    public BaseResponse<Void> announcementDelete(@PathVariable Long announcementId) {
         announcementService.deleteAnnouncement(announcementId);
 
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok();
     }
 
 }

--- a/rest/src/main/java/com/wherecar/rest/announcement/presentation/AnnouncementController.java
+++ b/rest/src/main/java/com/wherecar/rest/announcement/presentation/AnnouncementController.java
@@ -11,6 +11,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+// Todo: 권한 체크 추후 추가 예정
+
 @Slf4j
 @RestController
 @RequestMapping("/api/announcements")

--- a/rest/src/main/java/com/wherecar/rest/announcement/presentation/AnnouncementController.java
+++ b/rest/src/main/java/com/wherecar/rest/announcement/presentation/AnnouncementController.java
@@ -8,6 +8,7 @@ import com.wherecar.rest.common.response.BaseResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @Slf4j
@@ -20,7 +21,7 @@ public class AnnouncementController {
 
     // 공지 사항 등록
     @PostMapping
-    public BaseResponse<AnnouncementResponse> announcementCreate(@RequestBody AnnouncementRequest announcementRequest) {
+    public ResponseEntity<BaseResponse<AnnouncementResponse>> announcementCreate(@RequestBody AnnouncementRequest announcementRequest) {
         AnnouncementResponse announcementResponse = announcementService.createAnnouncement(announcementRequest);
 
         return BaseResponse.created(announcementResponse);
@@ -28,7 +29,7 @@ public class AnnouncementController {
 
     // 공지 사항 목록 조회
     @GetMapping
-    public BaseResponse<Page<AnnouncementResponse>> announcementsGet(
+    public ResponseEntity<BaseResponse<Page<AnnouncementResponse>>> announcementsGet(
             @RequestParam(value = "page", defaultValue = "" + PaginationConstants.DEFAULT_PAGE) int page,
             @RequestParam(value = "size", defaultValue = "" + PaginationConstants.DEFAULT_SIZE) int size)
     {
@@ -39,7 +40,7 @@ public class AnnouncementController {
 
     // 공지 사항 글 조회
     @GetMapping("/{announcementId}")
-    public BaseResponse<AnnouncementResponse> announcementGetDetail(@PathVariable Long announcementId) {
+    public ResponseEntity<BaseResponse<AnnouncementResponse>> announcementGetDetail(@PathVariable Long announcementId) {
         AnnouncementResponse announcement = announcementService.getAnnouncementDetail(announcementId);
 
         return BaseResponse.ok(announcement);
@@ -47,7 +48,7 @@ public class AnnouncementController {
 
     // 공지 사항 수정
     @PutMapping("/{announcementId}")
-    public BaseResponse<AnnouncementResponse> announcementUpdate(@PathVariable Long announcementId, @RequestBody AnnouncementRequest announcementRequest) {
+    public ResponseEntity<BaseResponse<AnnouncementResponse>> announcementUpdate(@PathVariable Long announcementId, @RequestBody AnnouncementRequest announcementRequest) {
         AnnouncementResponse announcementResponse = announcementService.updateAnnouncement(announcementId, announcementRequest);
 
         return BaseResponse.created(announcementResponse);
@@ -55,7 +56,7 @@ public class AnnouncementController {
 
     // 공지 사항 삭제
     @DeleteMapping("/{announcementId}")
-    public BaseResponse<Void> announcementDelete(@PathVariable Long announcementId) {
+    public ResponseEntity<BaseResponse<Void>> announcementDelete(@PathVariable Long announcementId) {
         announcementService.deleteAnnouncement(announcementId);
 
         return BaseResponse.ok();

--- a/rest/src/main/java/com/wherecar/rest/car/presentation/CarController.java
+++ b/rest/src/main/java/com/wherecar/rest/car/presentation/CarController.java
@@ -5,6 +5,7 @@ import com.wherecar.rest.car.application.dto.CarOverviewResponse;
 import com.wherecar.rest.car.application.dto.CarRegisterRequest;
 import com.wherecar.rest.car.application.dto.CarResponse;
 import com.wherecar.rest.common.constants.PaginationConstants;
+import com.wherecar.rest.common.response.BaseResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,26 +23,26 @@ public class CarController {
     private final CarService carService;
 
     @PostMapping
-    public ResponseEntity<Void> CarCreate(HttpServletRequest request, @RequestBody CarRegisterRequest registerCarRequest) {
+    public ResponseEntity<BaseResponse<CarResponse>> CarCreate(HttpServletRequest request, @RequestBody CarRegisterRequest registerCarRequest) {
         Long companyId = (Long)request.getAttribute("companyId");
-        carService.createCar(companyId, registerCarRequest);
-        return ResponseEntity.ok().build();
+        CarResponse carResponse = carService.createCar(companyId, registerCarRequest);
+        return BaseResponse.created(carResponse);
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity<Void> CarUpdate(@PathVariable Long id, @RequestBody CarRegisterRequest registerCarRequest) {
-        carService.updateCar(id, registerCarRequest);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<BaseResponse<CarResponse>> CarUpdate(@PathVariable Long id, @RequestBody CarRegisterRequest registerCarRequest) {
+        CarResponse carResponse = carService.updateCar(id, registerCarRequest);
+        return BaseResponse.created(carResponse);
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> CarDelete(@PathVariable Long id) {
+    public ResponseEntity<BaseResponse<Void>> CarDelete(@PathVariable Long id) {
         carService.deleteCar(id);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok();
     }
 
     @GetMapping
-    public ResponseEntity<List<CarResponse>> CarsGetAll(
+    public ResponseEntity<BaseResponse<List<CarResponse>>> CarsGetAll(
             HttpServletRequest request,
             @RequestParam(value = "page", defaultValue = "" + PaginationConstants.DEFAULT_PAGE) int page,
             @RequestParam(value = "size", defaultValue = "" + PaginationConstants.DEFAULT_SIZE) int size) {
@@ -49,21 +50,21 @@ public class CarController {
         Long companyId = (Long)request.getAttribute("companyId");
         List<CarResponse> cars = carService.getAllCars(companyId, page, size);
         log.info("CarsGetAll cars size {}, companyId {}", cars.size(), companyId);
-        return ResponseEntity.ok(cars);
+        return BaseResponse.ok(cars);
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<CarResponse> CarGetDetails(@PathVariable Long id) {
-        CarResponse car = carService.getCarDetails(id);
-        return ResponseEntity.ok(car);
+    public ResponseEntity<BaseResponse<CarResponse>> CarGetDetails(@PathVariable Long id) {
+        CarResponse carResponse = carService.getCarDetails(id);
+        return BaseResponse.ok(carResponse);
     }
 
     //정보별 차량 수 반환
     @GetMapping("/overview")
-    public ResponseEntity<CarOverviewResponse> CarGetOverview(HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<CarOverviewResponse>> CarGetOverview(HttpServletRequest request) {
         Long companyId = (Long)request.getAttribute("companyId");
         CarOverviewResponse info = carService.getCarOverview(companyId);
-        return ResponseEntity.ok(info);
+        return BaseResponse.ok(info);
     }
 
 }

--- a/rest/src/main/java/com/wherecar/rest/car/presentation/CarController.java
+++ b/rest/src/main/java/com/wherecar/rest/car/presentation/CarController.java
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+// Todo: 권한 체크 추후 추가 예정
 @Slf4j
 @RestController
 @RequestMapping("/api/cars")
@@ -21,6 +22,7 @@ import java.util.List;
 public class CarController {
 
     private final CarService carService;
+
 
     @PostMapping
     public ResponseEntity<BaseResponse<CarResponse>> CarCreate(HttpServletRequest request, @RequestBody CarRegisterRequest registerCarRequest) {

--- a/rest/src/main/java/com/wherecar/rest/carlog/application/CarLogService.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/application/CarLogService.java
@@ -12,7 +12,7 @@ public interface CarLogService {
 
     CarLogResponse getCarLogDetails(Long carLogId);
 
-    void updateCarLogDetails(Long carLogId, CarLogsUpdateRequest carLogsUpdateRequest);
+    CarLogResponse updateCarLogDetails(Long carLogId, CarLogsUpdateRequest carLogsUpdateRequest);
 
     void deleteCarLogDetails(Long carLogId);
 

--- a/rest/src/main/java/com/wherecar/rest/carlog/application/CarLogServiceImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/application/CarLogServiceImpl.java
@@ -63,12 +63,12 @@ public class CarLogServiceImpl implements CarLogService {
 
     //운행일지 상세 정보 수정
     @Override
-    public void updateCarLogDetails(Long carLogId, CarLogsUpdateRequest carLogsUpdateRequest) {
+    public CarLogResponse updateCarLogDetails(Long carLogId, CarLogsUpdateRequest carLogsUpdateRequest) {
 
         CarLog carLog = carLogReader.getCarLogById(carLogId);
         carLog.updateCarLog(carLogsUpdateRequest);
-        carLogStore.store(carLog);
-
+        carLog = carLogStore.store(carLog);
+        return carLogFactory.toCarLogResponse(carLog);
     }
 
     //운행일지 상세 정보 삭제

--- a/rest/src/main/java/com/wherecar/rest/carlog/presentation/CarLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/presentation/CarLogController.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+// Todo: 권한 체크 추후 추가 예정
+
 @Slf4j
 @RestController
 @RequestMapping("/api/carLogs")

--- a/rest/src/main/java/com/wherecar/rest/carlog/presentation/CarLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/presentation/CarLogController.java
@@ -1,10 +1,11 @@
 package com.wherecar.rest.carlog.presentation;
 
-import com.wherecar.rest.carlog.application.dto.CarLogResponse;
-import com.wherecar.rest.common.constants.PaginationConstants;
-import com.wherecar.rest.carlog.application.dto.CarLogFilterRequest;
-import com.wherecar.rest.carlog.application.dto.CarLogsUpdateRequest;
 import com.wherecar.rest.carlog.application.CarLogService;
+import com.wherecar.rest.carlog.application.dto.CarLogFilterRequest;
+import com.wherecar.rest.carlog.application.dto.CarLogResponse;
+import com.wherecar.rest.carlog.application.dto.CarLogsUpdateRequest;
+import com.wherecar.rest.common.constants.PaginationConstants;
+import com.wherecar.rest.common.response.BaseResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -22,7 +23,7 @@ class CarLogController {
 
     //운행일지 목록 조회 (filter 추가)
     @PostMapping
-    public ResponseEntity<Page<CarLogResponse>> carLogsGetWithFilter(
+    public ResponseEntity<BaseResponse<Page<CarLogResponse>>> carLogsGetWithFilter(
             HttpServletRequest httpServletRequest,
             @RequestParam(value = "page", defaultValue = "" + PaginationConstants.DEFAULT_PAGE) int page,
             @RequestParam(value = "size", defaultValue = "" + PaginationConstants.DEFAULT_SIZE) int size,
@@ -42,40 +43,40 @@ class CarLogController {
                 size
         );
 
-        return ResponseEntity.ok(carLogs);
+        return BaseResponse.created(carLogs);
     }
 
     //운행일지 상세 정보 조회
     @GetMapping("/{logId}")
-    public ResponseEntity<CarLogResponse> carLogsGetDetails(@PathVariable Long logId) {
+    public ResponseEntity<BaseResponse<CarLogResponse>> carLogsGetDetails(@PathVariable Long logId) {
         CarLogResponse carLogs = carLogService.getCarLogDetails(logId);
-        return ResponseEntity.ok(carLogs);
+        return BaseResponse.ok(carLogs);
     }
 
     //운행일지 상세 정보 수정
     @PutMapping("/{logId}")
-    public ResponseEntity<Void> carLogUpdateDetails(@PathVariable Long logId, @RequestBody CarLogsUpdateRequest carLogsUpdateRequest) {
-        carLogService.updateCarLogDetails(logId, carLogsUpdateRequest);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<BaseResponse<CarLogResponse>> carLogUpdateDetails(@PathVariable Long logId, @RequestBody CarLogsUpdateRequest carLogsUpdateRequest) {
+        CarLogResponse carLogResponse = carLogService.updateCarLogDetails(logId, carLogsUpdateRequest);
+        return BaseResponse.created(carLogResponse);
     }
 
 
     //운행일지 상세 정보 삭제
     @DeleteMapping("/{logId}")
-    public ResponseEntity<Void> carLogDeleteDetails(@PathVariable Long logId) {
+    public ResponseEntity<BaseResponse<Void>> carLogDeleteDetails(@PathVariable Long logId) {
         carLogService.deleteCarLogDetails(logId);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok();
     }
 
     // 대시보드 운행 통계 달별 km 및 운행건수를 counting
     @GetMapping("/statics")
-    public ResponseEntity<CarLogResponse> carLogsStaticsGetAll(HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<CarLogResponse>> carLogsStaticsGetAll(HttpServletRequest request) {
 
         Long companyId = (Long)request.getAttribute("companyId");
         System.out.println("companyId = " + companyId);
         CarLogResponse carLogsStaticsResponse = carLogService.getAllCarLogsStatics(companyId);
 
-        return ResponseEntity.ok(carLogsStaticsResponse);
+        return BaseResponse.ok(carLogsStaticsResponse);
     }
 
 }

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/presentation/CarLogSummaryController.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/presentation/CarLogSummaryController.java
@@ -16,6 +16,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
+// Todo: 권한 체크 추후 추가 예정
+
 @Slf4j
 @RestController
 @RequestMapping("/api/stat")

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/presentation/CarLogSummaryController.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/presentation/CarLogSummaryController.java
@@ -2,6 +2,7 @@ package com.wherecar.rest.carlogsummary.presentation;
 
 import com.wherecar.rest.carlogsummary.application.CarLogSummaryService;
 import com.wherecar.rest.carlogsummary.application.dto.CarLogSummaryOverviewResponse;
+import com.wherecar.rest.common.response.BaseResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +24,7 @@ public class CarLogSummaryController {
     private final CarLogSummaryService carLogSummaryService;
 
     @GetMapping("/companies/my")
-    public ResponseEntity<CarLogSummaryOverviewResponse> carLogSummaryOverviewGetByCompanyId(HttpServletRequest request, @RequestParam String from, @RequestParam String to) {
+    public ResponseEntity<BaseResponse<CarLogSummaryOverviewResponse>> carLogSummaryOverviewGetByCompanyId(HttpServletRequest request, @RequestParam String from, @RequestParam String to) {
         Long companyId = (Long)request.getAttribute("companyId");
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 
@@ -33,17 +34,17 @@ public class CarLogSummaryController {
         CarLogSummaryOverviewResponse overviewResponse =
                 carLogSummaryService.getCarLogSummaryOverviewByCompanyId(companyId, fromDateTime, toDateTime);
 
-        return ResponseEntity.ok(overviewResponse);
+        return BaseResponse.ok(overviewResponse);
     }
 
     @GetMapping("/mdn")
-    public ResponseEntity<CarLogSummaryOverviewResponse> carLogSummaryOverviewGetByMdn(@RequestParam String mdn, @RequestParam String from, @RequestParam String to) {
+    public ResponseEntity<BaseResponse<CarLogSummaryOverviewResponse>> carLogSummaryOverviewGetByMdn(@RequestParam String mdn, @RequestParam String from, @RequestParam String to) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");
 
         LocalDateTime fromDateTime = LocalDate.parse(from, formatter).atStartOfDay();
         LocalDateTime toDateTime = LocalDate.parse(to, formatter).atTime(23, 59, 59);
 
         CarLogSummaryOverviewResponse overviewResponse = carLogSummaryService.getCarLogSummaryOverviewByMdn(mdn, fromDateTime, toDateTime);
-        return ResponseEntity.ok(overviewResponse);
+        return BaseResponse.ok(overviewResponse);
     }
 }

--- a/rest/src/main/java/com/wherecar/rest/common/exception/GlobalExceptionHandler.java
+++ b/rest/src/main/java/com/wherecar/rest/common/exception/GlobalExceptionHandler.java
@@ -1,20 +1,15 @@
 package com.wherecar.rest.common.exception;
 
 import com.wherecar.rest.common.response.BaseResponse;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
-    @ExceptionHandler(DuplicateEmailException.class)
-    public BaseResponse<Void> handleDuplicateEmailException(DuplicateEmailException e) {
-        return BaseResponse.badRequest(e.getMessage());
-    }
-
-
     @ExceptionHandler(Exception.class)
-    public BaseResponse<Void> handleException(Exception e) {
+    public ResponseEntity<BaseResponse<Void>> handleException(Exception e) {
         return BaseResponse.badRequest(e.getMessage());
     }
 }

--- a/rest/src/main/java/com/wherecar/rest/common/response/BaseResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/common/response/BaseResponse.java
@@ -3,6 +3,8 @@ package com.wherecar.rest.common.response;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 @Data
 public class BaseResponse<T> {
@@ -24,67 +26,81 @@ public class BaseResponse<T> {
         this.statusCode = statusCode;
     }
 
+    // ====== 성공 응답 ======
 
-    // 200 OK
-    public static <T> BaseResponse<T> ok() {
-        return new BaseResponse<>(HttpStatusCode.OK.getMessage(), HttpStatusCode.OK.getStatusCode());
+    public static <T> ResponseEntity<BaseResponse<T>> ok() {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new BaseResponse<>(HttpStatus.OK.getReasonPhrase(), HttpStatus.OK.value()));
     }
 
-    // 200 OK
-    public static <T> BaseResponse<T> ok(T data) {
-        return new BaseResponse<>(data, HttpStatusCode.OK.getMessage(), HttpStatusCode.OK.getStatusCode());
+    public static <T> ResponseEntity<BaseResponse<T>> ok(T data) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new BaseResponse<>(data, HttpStatus.OK.getReasonPhrase(), HttpStatus.OK.value()));
     }
 
-    // 201 Created
-    public static <T> BaseResponse<T> created(T data) {
-        return new BaseResponse<>(data, HttpStatusCode.CREATED.getMessage(), HttpStatusCode.CREATED.getStatusCode());
+    public static <T> ResponseEntity<BaseResponse<T>> created(T data) {
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(new BaseResponse<>(data, HttpStatus.CREATED.getReasonPhrase(), HttpStatus.CREATED.value()));
     }
 
-    // 202 Accepted
-    public static <T> BaseResponse<T> accepted(String message) {
-        return new BaseResponse<>(HttpStatusCode.ACCEPTED.getMessage(), HttpStatusCode.ACCEPTED.getStatusCode());
+    public static <T> ResponseEntity<BaseResponse<T>> accepted(String message) {
+        return ResponseEntity
+                .status(HttpStatus.ACCEPTED)
+                .body(new BaseResponse<>(message, HttpStatus.ACCEPTED.value()));
     }
 
-    // 204 No Content
-    public static <T> BaseResponse<T> noContent(String message) {
-        return new BaseResponse<>(message, HttpStatusCode.NO_CONTENT.getStatusCode());
+    public static <T> ResponseEntity<BaseResponse<T>> noContent(String message) {
+        return ResponseEntity
+                .status(HttpStatus.NO_CONTENT)
+                .body(new BaseResponse<>(message, HttpStatus.NO_CONTENT.value()));
     }
 
-    // 400 Bad Request
-    public static <T> BaseResponse<T> badRequest(String message) {
-        return new BaseResponse<>(message, HttpStatusCode.BAD_REQUEST.getStatusCode());
+    // ====== 클라이언트 오류 응답 ======
+
+    public static <T> ResponseEntity<BaseResponse<T>> badRequest(String message) {
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(new BaseResponse<>(message, HttpStatus.BAD_REQUEST.value()));
     }
 
-    // 401 Unauthorized
-    public static <T> BaseResponse<T> unauthorized(String message) {
-        return new BaseResponse<>(message, HttpStatusCode.UNAUTHORIZED.getStatusCode());
+    public static <T> ResponseEntity<BaseResponse<T>> unauthorized(String message) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(new BaseResponse<>(message, HttpStatus.UNAUTHORIZED.value()));
     }
 
-    // 403 Forbidden
-    public static <T> BaseResponse<T> forbidden(String message) {
-        return new BaseResponse<>(message, HttpStatusCode.FORBIDDEN.getStatusCode());
+    public static <T> ResponseEntity<BaseResponse<T>> forbidden(String message) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(new BaseResponse<>(message, HttpStatus.FORBIDDEN.value()));
     }
 
-    // 404 Not Found
-    public static <T> BaseResponse<T> notFound(String message) {
-        return new BaseResponse<>(message, HttpStatusCode.NOT_FOUND.getStatusCode());
+    public static <T> ResponseEntity<BaseResponse<T>> notFound(String message) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new BaseResponse<>(message, HttpStatus.NOT_FOUND.value()));
     }
 
+    // ====== 서버 오류 응답 ======
 
-    // 500 Internal Server Error
-    public static <T> BaseResponse<T> internalServerError(String message) {
-        return new BaseResponse<>(message, HttpStatusCode.INTERNAL_SERVER_ERROR.getStatusCode());
+    public static <T> ResponseEntity<BaseResponse<T>> internalServerError(String message) {
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(new BaseResponse<>(message, HttpStatus.INTERNAL_SERVER_ERROR.value()));
     }
 
+    // ====== JSON 출력 ======
 
     @Override
     public String toString() {
         try {
-            return objectMapper.writeValueAsString(this);  // JSON 형식으로 반환
+            return objectMapper.writeValueAsString(this);
         } catch (JsonProcessingException e) {
             e.printStackTrace();
-            return "{\"data\":null,\"message\":\"서버 내부 오류입니다(JSON 변환).\",\"statusCode\":500}";  // 예외 발생 시 빈 객체 반환
+            return "{\"data\":null,\"message\":\"서버 내부 오류입니다(JSON 변환).\",\"statusCode\":500}";
         }
     }
-
 }

--- a/rest/src/main/java/com/wherecar/rest/company/presentation/CompanyController.java
+++ b/rest/src/main/java/com/wherecar/rest/company/presentation/CompanyController.java
@@ -6,9 +6,13 @@ import com.wherecar.rest.company.application.dto.CompanyRequest;
 import com.wherecar.rest.company.application.dto.CompanyResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+// Todo: 권한 체크 추후 추가 예정
+
+@Slf4j
 @RestController
 @RequestMapping("/api/companies")
 @RequiredArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/company/presentation/CompanyController.java
+++ b/rest/src/main/java/com/wherecar/rest/company/presentation/CompanyController.java
@@ -1,8 +1,9 @@
 package com.wherecar.rest.company.presentation;
 
+import com.wherecar.rest.common.response.BaseResponse;
+import com.wherecar.rest.company.application.CompanyService;
 import com.wherecar.rest.company.application.dto.CompanyRequest;
 import com.wherecar.rest.company.application.dto.CompanyResponse;
-import com.wherecar.rest.company.application.CompanyService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -15,24 +16,25 @@ public class CompanyController {
 
     private final CompanyService companyService;
 
+
     @GetMapping("/my")
-    public ResponseEntity<CompanyResponse> myCompanyDetailsGet(HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<CompanyResponse>> myCompanyDetailsGet(HttpServletRequest request) {
         Long companyId = (Long)request.getAttribute("companyId");
-        CompanyResponse company = companyService.getCompanyDetails(companyId);
-        return ResponseEntity.ok(company);
+        CompanyResponse companyResponse = companyService.getCompanyDetails(companyId);
+        return BaseResponse.ok(companyResponse);
     }
 
     @PutMapping("/my")
-    public ResponseEntity<Void> myCompanyUpdate(HttpServletRequest request, @RequestBody CompanyRequest companyRequest) {
+    public ResponseEntity<BaseResponse<CompanyResponse>> myCompanyUpdate(HttpServletRequest request, @RequestBody CompanyRequest companyRequest) {
         Long companyId = (Long)request.getAttribute("companyId");
-        companyService.updateCompany(companyId, companyRequest);
-        return ResponseEntity.ok().build();
+        CompanyResponse companyResponse = companyService.updateCompany(companyId, companyRequest);
+        return BaseResponse.created(companyResponse);
     }
 
     @DeleteMapping("/my")
-    public ResponseEntity<Void> myCompanyDelete(HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> myCompanyDelete(HttpServletRequest request) {
         Long companyId = (Long)request.getAttribute("companyId");
         companyService.deleteCompany(companyId);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok();
     }
 }

--- a/rest/src/main/java/com/wherecar/rest/geoinfo/application/dto/GeoInfoResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/geoinfo/application/dto/GeoInfoResponse.java
@@ -1,5 +1,6 @@
 package com.wherecar.rest.geoinfo.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -18,6 +19,9 @@ public class GeoInfoResponse {
     private String geoRange;
     private Double latitude;
     private Double longitude;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime onTime;
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime offTime;
 }

--- a/rest/src/main/java/com/wherecar/rest/geoinfo/application/dto/emulator/GeoResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/geoinfo/application/dto/emulator/GeoResponse.java
@@ -1,5 +1,6 @@
 package com.wherecar.rest.geoinfo.application.dto.emulator;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,6 +20,10 @@ public class GeoResponse {
     private String geoRange;        // 지오펜스 반경
     private Integer latitude;        // 위도
     private Integer longitude;       // 경도
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime onTime;   // 시작 시간
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime offTime;  // 종료 시간
 }

--- a/rest/src/main/java/com/wherecar/rest/geoinfo/presentation/GeoInfoController.java
+++ b/rest/src/main/java/com/wherecar/rest/geoinfo/presentation/GeoInfoController.java
@@ -6,11 +6,14 @@ import com.wherecar.rest.geoinfo.application.dto.GeoInfoRequest;
 import com.wherecar.rest.geoinfo.application.dto.GeoInfoResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
+// Todo: 권한 체크 추후 추가 예정
 
+import java.util.List;
+@Slf4j
 @RestController
 @RequestMapping("/api/geoInfos")
 @RequiredArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/geoinfo/presentation/GeoInfoController.java
+++ b/rest/src/main/java/com/wherecar/rest/geoinfo/presentation/GeoInfoController.java
@@ -1,8 +1,9 @@
 package com.wherecar.rest.geoinfo.presentation;
 
+import com.wherecar.rest.common.response.BaseResponse;
+import com.wherecar.rest.geoinfo.application.GeoInfoService;
 import com.wherecar.rest.geoinfo.application.dto.GeoInfoRequest;
 import com.wherecar.rest.geoinfo.application.dto.GeoInfoResponse;
-import com.wherecar.rest.geoinfo.application.GeoInfoService;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -18,13 +19,12 @@ public class GeoInfoController {
     private final GeoInfoService geoInfoService;
 
     // GeoFence 정보 등록
-    @PostMapping("/create")
-
-    public ResponseEntity<Void> geoInfoCreate(HttpServletRequest request, @RequestBody GeoInfoRequest geoInfoRequest) {
+    @PostMapping
+    public ResponseEntity<BaseResponse<GeoInfoResponse>> geoInfoCreate(HttpServletRequest request, @RequestBody GeoInfoRequest geoInfoRequest) {
         Long companyId = (Long)request.getAttribute("companyId");
-        geoInfoService.createGeoInfo(companyId, geoInfoRequest);
+        GeoInfoResponse geoInfoResponse = geoInfoService.createGeoInfo(companyId, geoInfoRequest);
 
-        return ResponseEntity.ok().build();
+        return BaseResponse.created(geoInfoResponse);
 
     }
 
@@ -36,37 +36,37 @@ public class GeoInfoController {
 
     // GeoInfo 조회
     @GetMapping("/{id}")
-    public ResponseEntity<GeoInfoResponse> geoInfoGet(@PathVariable Long id) {
+    public ResponseEntity<BaseResponse<GeoInfoResponse>> geoInfoGet(@PathVariable Long id) {
 
         GeoInfoResponse geoInfoResponse = geoInfoService.getGeoInfo(id);
 
-        return ResponseEntity.ok(geoInfoResponse);
+        return BaseResponse.ok(geoInfoResponse);
 
     }
 
     // GeoInfo 수정
     @PutMapping("/{id}")
-    public ResponseEntity<Void> geoInfoUpdate(@PathVariable Long id, @RequestBody GeoInfoRequest geoInfoRequest) {
+    public ResponseEntity<BaseResponse<GeoInfoResponse>> geoInfoUpdate(@PathVariable Long id, @RequestBody GeoInfoRequest geoInfoRequest) {
 
-        geoInfoService.updateGeoInfo(id, geoInfoRequest);
+        GeoInfoResponse geoInfoResponse = geoInfoService.updateGeoInfo(id, geoInfoRequest);
 
-        return ResponseEntity.ok().build();
+        return BaseResponse.created(geoInfoResponse);
     }
 
     // GeoInfo 삭제
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> geoInfoDelete(@PathVariable Long id) {
+    public ResponseEntity<BaseResponse<Void>> geoInfoDelete(@PathVariable Long id) {
 
         geoInfoService.deleteGeoInfo(id);
 
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok();
 
     }
 
     @GetMapping("/companies/my")
-    public ResponseEntity<List<GeoInfoResponse>> geoInfoGetByMyCompany(HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<List<GeoInfoResponse>>> geoInfoGetByMyCompany(HttpServletRequest request) {
         Long companyId = (Long)request.getAttribute("companyId");
         List<GeoInfoResponse> geoInfoResponses = geoInfoService.getGeoInfosByCompanyId(companyId);
-        return ResponseEntity.ok(geoInfoResponses);
+        return BaseResponse.ok(geoInfoResponses);
     }
 }

--- a/rest/src/main/java/com/wherecar/rest/geolog/presentation/GeoLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/geolog/presentation/GeoLogController.java
@@ -1,5 +1,6 @@
 package com.wherecar.rest.geolog.presentation;
 
+import com.wherecar.rest.common.response.BaseResponse;
 import com.wherecar.rest.geolog.application.GeoLogService;
 import com.wherecar.rest.geolog.application.dto.GeoLogRequest;
 import com.wherecar.rest.geolog.application.dto.GeoLogResponse;
@@ -19,27 +20,27 @@ public class GeoLogController {
     private final GeoLogService geoLogService;
 
     @GetMapping("/cars/{carId}")
-    public ResponseEntity<List<GeoLogResponse>> geoLogGetByCarId(@PathVariable Long carId) {
+    public ResponseEntity<BaseResponse<List<GeoLogResponse>>> geoLogGetByCarId(@PathVariable Long carId) {
         List<GeoLogResponse> geoLogResponses = geoLogService.getGeoLogsByCarId(carId);
-        return ResponseEntity.ok(geoLogResponses);
+        return BaseResponse.ok(geoLogResponses);
     }
 
     @GetMapping("/{geoLogId}")
-    public ResponseEntity<GeoLogResponse> geoLogGet(@PathVariable Long geoLogId) {
-        GeoLogResponse geoLog = geoLogService.getGeoLog(geoLogId);
-        return ResponseEntity.ok(geoLog);
+    public ResponseEntity<BaseResponse<GeoLogResponse>> geoLogGet(@PathVariable Long geoLogId) {
+        GeoLogResponse geoLogResponse = geoLogService.getGeoLog(geoLogId);
+        return BaseResponse.ok(geoLogResponse);
     }
 
     @PutMapping("/{geoLogId}")
-    public ResponseEntity<Void> geoLogUpdate(@PathVariable Long geoLogId, @RequestBody GeoLogRequest geoLogRequest) {
-        geoLogService.updateGeoLog(geoLogId, geoLogRequest);
-        return ResponseEntity.ok().build();
+    public ResponseEntity<BaseResponse<GeoLogResponse>> geoLogUpdate(@PathVariable Long geoLogId, @RequestBody GeoLogRequest geoLogRequest) {
+        GeoLogResponse geoLogResponse = geoLogService.updateGeoLog(geoLogId, geoLogRequest);
+        return BaseResponse.created(geoLogResponse);
     }
 
     @DeleteMapping("/{geoLogId}")
-    public ResponseEntity<Void> geoLogDelete(@PathVariable Long geoLogId) {
+    public ResponseEntity<BaseResponse<Void>> geoLogDelete(@PathVariable Long geoLogId) {
         geoLogService.deleteGeoLog(geoLogId);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok();
     }
 
 }

--- a/rest/src/main/java/com/wherecar/rest/geolog/presentation/GeoLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/geolog/presentation/GeoLogController.java
@@ -11,6 +11,8 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+// Todo: 권한 체크 추후 추가 예정
+
 @Slf4j
 @RestController
 @RequestMapping("/api/geoLogs")

--- a/rest/src/main/java/com/wherecar/rest/gpslog/application/dto/GpsLogResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/gpslog/application/dto/GpsLogResponse.java
@@ -1,5 +1,6 @@
 package com.wherecar.rest.gpslog.application.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -11,5 +12,7 @@ public class GpsLogResponse {
     private String mdn;
     private double latitude;
     private double longitude;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime timestamp;
 }

--- a/rest/src/main/java/com/wherecar/rest/gpslog/presentation/GpsLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/gpslog/presentation/GpsLogController.java
@@ -10,6 +10,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+// Todo: 권한 체크 추후 추가 예정
+
 @Slf4j
 @RestController
 @RequestMapping("/api/gps")

--- a/rest/src/main/java/com/wherecar/rest/gpslog/presentation/GpsLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/gpslog/presentation/GpsLogController.java
@@ -1,9 +1,10 @@
 package com.wherecar.rest.gpslog.presentation;
 
+import com.wherecar.rest.common.response.BaseResponse;
+import com.wherecar.rest.gpslog.application.GpsLogService;
 import com.wherecar.rest.gpslog.application.dto.GpsLogRequest;
 import com.wherecar.rest.gpslog.application.dto.GpsLogResponse;
 import com.wherecar.rest.gpslog.application.dto.GpsRouteResponse;
-import com.wherecar.rest.gpslog.application.GpsLogService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -18,23 +19,16 @@ public class GpsLogController {
     private final GpsLogService gpsLogService;
 
     @GetMapping("/position")
-    public ResponseEntity<GpsLogResponse> LocationGetLatest(@RequestParam String mdn) {
+    public ResponseEntity<BaseResponse<GpsLogResponse>> LocationGetLatest(@RequestParam String mdn) {
         GpsLogResponse gpsLogResponse = gpsLogService.getLatestGpsLogByMdn(mdn);
-        return ResponseEntity.ok(gpsLogResponse);
+        return BaseResponse.ok(gpsLogResponse);
     }
 
     @PostMapping("/route")
-    public ResponseEntity<GpsRouteResponse> routeGet(
-            @RequestBody GpsLogRequest request
-    ) {
+    public ResponseEntity<BaseResponse<GpsRouteResponse>> routeGet(@RequestBody GpsLogRequest request) {
         log.info("routeGet request {}", request);
-        return ResponseEntity.ok(gpsLogService
-                .getGpsPointsByMdn(
-                        request.getMdn(),
-                        request.getStartTime(),
-                        request.getEndTime()
-                )
-        );
+        GpsRouteResponse gpsRouteResponse = gpsLogService.getGpsPointsByMdn(request.getMdn(), request.getStartTime(), request.getEndTime());
+        return BaseResponse.created(gpsRouteResponse);
     }
 
 }

--- a/rest/src/main/java/com/wherecar/rest/user/presentation/UserController.java
+++ b/rest/src/main/java/com/wherecar/rest/user/presentation/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
+// Todo: 권한 체크 추후 추가 예정
 @Slf4j
 @RestController
 @RequestMapping("/api/users")

--- a/rest/src/main/java/com/wherecar/rest/user/presentation/UserController.java
+++ b/rest/src/main/java/com/wherecar/rest/user/presentation/UserController.java
@@ -1,7 +1,8 @@
 package com.wherecar.rest.user.presentation;
 
-import com.wherecar.rest.user.application.dto.*;
+import com.wherecar.rest.common.response.BaseResponse;
 import com.wherecar.rest.user.application.UserService;
+import com.wherecar.rest.user.application.dto.*;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -18,87 +19,87 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping("/root")
-    public ResponseEntity<Void> rootCreate(@RequestBody RootUserRequest rootUserRequest) {
+    public ResponseEntity<BaseResponse<UserResponse>> rootCreate(@RequestBody RootUserRequest rootUserRequest) {
         log.info("Creating root user with company: {}", rootUserRequest);
-        userService.createRoot(rootUserRequest);
-        return ResponseEntity.ok().build();
+        UserResponse userResponse = userService.createRoot(rootUserRequest);
+        return BaseResponse.created(userResponse);
     }
 
 //    @RequiredPermission(PermissionType.SUB_USER_CREATE)
     @PostMapping("/sub")
-    public ResponseEntity<Void> subCreate(HttpServletRequest request, @RequestBody SubUserRequest subUserRequest) {
+    public ResponseEntity<BaseResponse<UserResponse>> subCreate(HttpServletRequest request, @RequestBody SubUserRequest subUserRequest) {
         log.info("Creating sub user: {}", subUserRequest);
         Long companyId = (Long)request.getAttribute("companyId");
-        userService.createSub(subUserRequest, companyId);
-        return ResponseEntity.ok().build();
+        UserResponse userResponse = userService.createSub(subUserRequest, companyId);
+        return BaseResponse.created(userResponse);
     }
 //    @RequiredPermission(PermissionType.USER_VIEW)
     @GetMapping("/companies/my")
-    public ResponseEntity<List<UserResponse>> usersGetOfCompany(HttpServletRequest request){
+    public ResponseEntity<BaseResponse<List<UserResponse>>> usersGetOfCompany(HttpServletRequest request){
         Long companyId = (Long)request.getAttribute("companyId");
         log.info("Retrieving users with company");
         List<UserResponse> userResponses = userService.getUsersOfCompany(companyId);
-        return ResponseEntity.ok(userResponses);
+        return BaseResponse.ok(userResponses);
     }
 
 //    @RequiredPermission(PermissionType.USER_VIEW)
     @GetMapping("/{userId}")
-    public ResponseEntity<UserResponse> userGet(@PathVariable Long userId){
+    public ResponseEntity<BaseResponse<UserResponse>> userGet(@PathVariable Long userId){
         log.info("Retrieving user with id: {}", userId);
         UserResponse userResponse = userService.getUserById(userId);
-        return ResponseEntity.ok(userResponse);
+        return BaseResponse.ok(userResponse);
     }
 
 //    @RequiredPermission(PermissionType.USER_VIEW)
     @GetMapping("/my")
-    public ResponseEntity<UserResponse> myUserGet(HttpServletRequest request){
+    public ResponseEntity<BaseResponse<UserResponse>> myUserGet(HttpServletRequest request){
         Long userId = (Long)request.getAttribute("userId");
         log.info("Retrieving user with id: {}", userId);
         UserResponse userResponse = userService.getUserById(userId);
-        return ResponseEntity.ok(userResponse);
+        return BaseResponse.ok(userResponse);
     }
 
 //    @RequiredPermission(PermissionType.ROOT)
     @DeleteMapping("/{userId}")
-    public ResponseEntity<Void> userDelete(@PathVariable Long userId){
+    public ResponseEntity<BaseResponse<Void>> userDelete(@PathVariable Long userId){
         log.info("Deleting user with id: {}", userId);
         userService.deleteUserById(userId);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok();
     }
 
 //    @RequiredPermission(PermissionType.ROOT)
     @DeleteMapping("/my")
-    public ResponseEntity<Void> myUserDelete(HttpServletRequest request){
+    public ResponseEntity<BaseResponse<Void>> myUserDelete(HttpServletRequest request){
         Long userId = (Long)request.getAttribute("userId");
         log.info("Deleting user with id: {}", userId);
         userService.deleteUserById(userId);
-        return ResponseEntity.ok().build();
+        return BaseResponse.ok();
     }
 
 //    @RequiredPermission(PermissionType.ROOT)
     @PutMapping("/{userId}")
-    public ResponseEntity<Void> userUpdate(@PathVariable Long userId, @RequestBody UserRequest userRequest){
+    public ResponseEntity<BaseResponse<UserResponse>> userUpdate(@PathVariable Long userId, @RequestBody UserRequest userRequest){
         log.info("Updating user with id: {}", userId);
-        userService.updateUserById(userId, userRequest);
-        return ResponseEntity.ok().build();
+        UserResponse userResponse = userService.updateUserById(userId, userRequest);
+        return BaseResponse.created(userResponse);
     }
 
 //    @RequiredPermission(PermissionType.ROOT)
     @PutMapping("/my")
-    public ResponseEntity<Void> myUserUpdate(HttpServletRequest request, @RequestBody UserRequest userRequest){
+    public ResponseEntity<BaseResponse<UserResponse>> myUserUpdate(HttpServletRequest request, @RequestBody UserRequest userRequest){
         Long userId = (Long)request.getAttribute("userId");
         log.info("Updating my user: {}", userId);
-        userService.updateUserById(userId, userRequest);
-        return ResponseEntity.ok().build();
+        UserResponse userResponse = userService.updateUserById(userId, userRequest);
+        return BaseResponse.created(userResponse);
     }
 
 //    @RequiredPermission(PermissionType.ROOT)
     @PutMapping("/password")
-    public ResponseEntity<Void> passwordUpdate(HttpServletRequest request, @RequestBody PasswordRequest passwordRequest){
+    public ResponseEntity<BaseResponse<UserResponse>> passwordUpdate(HttpServletRequest request, @RequestBody PasswordRequest passwordRequest){
         Long userId = (Long)request.getAttribute("userId");
         log.info("Updating password");
-        userService.updatePasswordById(userId, passwordRequest);
-        return ResponseEntity.ok().build();
+        UserResponse userResponse = userService.updatePasswordById(userId, passwordRequest);
+        return BaseResponse.created(userResponse);
     }
 
     //Permission
@@ -106,33 +107,33 @@ public class UserController {
 
 //    @RequiredPermission(PermissionType.ROOT)
     @PutMapping("/permissions/{userId}")
-    public ResponseEntity<Void> permissionUpdate(@PathVariable Long userId, @RequestBody PermissionRequest permissionRequest){
+    public ResponseEntity<BaseResponse<UserResponse>> permissionUpdate(@PathVariable Long userId, @RequestBody PermissionRequest permissionRequest){
         log.info("Adding permission with id: {}", userId);
-        userService.updatePermission(userId, permissionRequest);
-        return ResponseEntity.ok().build();
+        UserResponse userResponse = userService.updatePermission(userId, permissionRequest);
+        return BaseResponse.created(userResponse);
     }
 
     @PutMapping("/permissions/my")
-    public ResponseEntity<Void> myPermissionUpdate(HttpServletRequest request, @RequestBody PermissionRequest permissionRequest){
+    public ResponseEntity<BaseResponse<UserResponse>> myPermissionUpdate(HttpServletRequest request, @RequestBody PermissionRequest permissionRequest){
         Long userId = (Long)request.getAttribute("userId");
         log.info("Retrieving my permission with id: {}", userId);
-        userService.updatePermission(userId, permissionRequest);
-        return ResponseEntity.ok().build();
+        UserResponse userResponse = userService.updatePermission(userId, permissionRequest);
+        return BaseResponse.created(userResponse);
     }
 
 //    @RequiredPermission(PermissionType.ROOT)
     @GetMapping("/permissions/{userId}")
-    public ResponseEntity<PermissionResponse> permissionGet(@PathVariable Long userId){
+    public ResponseEntity<BaseResponse<PermissionResponse>> permissionGet(@PathVariable Long userId){
         log.info("Retrieving permission with id: {}", userId);
         PermissionResponse permissionResponse = userService.getPermissionById(userId);
-        return ResponseEntity.ok(permissionResponse);
+        return BaseResponse.ok(permissionResponse);
     }
 
     @GetMapping("/permissions/my")
-    public ResponseEntity<PermissionResponse> myPermissionGet(HttpServletRequest request){
+    public ResponseEntity<BaseResponse<PermissionResponse>> myPermissionGet(HttpServletRequest request){
         Long userId = (Long)request.getAttribute("userId");
         log.info("Retrieving my permission with id: {}", userId);
         PermissionResponse permissionResponse = userService.getPermissionById(userId);
-        return ResponseEntity.ok(permissionResponse);
+        return BaseResponse.ok(permissionResponse);
     }
 }


### PR DESCRIPTION
close #199

# 📝 작업 내용

## ✨ 주요 변경 사항
- 모든 컨트롤러 메서드가 `BaseResponse<T>`를 사용하여 응답 형식 통일
- 서비스 레이어에서 반환되는 객체를 `BaseResponse`로 감싸 `ResponseEntity`로 응답
- 기존의 `ResponseEntity.ok().build()` 형태는 `BaseResponse.ok()` 또는 `BaseResponse.created()`로 변경
- `BaseResponse` 클래스 내부에서 `HttpStatusCode` 대신 Spring의 `HttpStatus`를 사용하도록 리팩토링
- `LocalDateTime` 필드에 대해 `@JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")` 적용하여 JSON 직렬화 포맷 일관화

---

## ✅ 기대 효과
- API 응답 포맷의 **일관성 확보**
- 클라이언트 처리 및 오류 응답 구조 **간소화**
- Swagger / OpenAPI 문서화 시 **response 구조가 통일**
- 추후 `traceId`, `timestamp` 등 **공통 필드 확장 용이**

---

## 🔁 변경된 컨트롤러 목록
- `AnnouncementController`
- `CarController`
- `CarLogController`
- `CarLogSummaryController`
- `CompanyController`
- `GeoInfoController`
- `GeoLogController`
- `GpsLogController`
- `UserController`

