### PR TITLE
[#211] refactor: dto 일관적으로 request 랑 response

### DIFF
--- a/rest/src/main/java/com/wherecar/rest/announcement/application/dto/AnnouncementRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/announcement/application/dto/AnnouncementRequest.java
@@ -1,15 +1,11 @@
 package com.wherecar.rest.announcement.application.dto;
 
 import com.wherecar.rest.announcement.domain.constant.AnnouncementType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Setter
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@ToString
 public class AnnouncementRequest {
 
     private String title;

--- a/rest/src/main/java/com/wherecar/rest/announcement/application/dto/AnnouncementResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/announcement/application/dto/AnnouncementResponse.java
@@ -1,14 +1,13 @@
 package com.wherecar.rest.announcement.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
+@Setter
 @Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/car/application/dto/CarOverviewResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/car/application/dto/CarOverviewResponse.java
@@ -1,11 +1,10 @@
 package com.wherecar.rest.car.application.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Data
+@Setter
+@Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/car/application/dto/CarRegisterRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/car/application/dto/CarRegisterRequest.java
@@ -2,15 +2,11 @@ package com.wherecar.rest.car.application.dto;
 
 import com.wherecar.rest.car.domain.constant.AcquisitionType;
 import com.wherecar.rest.car.domain.constant.OwnerType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Setter
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@ToString
 public class CarRegisterRequest {
 
     private String mdn;

--- a/rest/src/main/java/com/wherecar/rest/car/application/dto/CarResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/car/application/dto/CarResponse.java
@@ -3,12 +3,11 @@ package com.wherecar.rest.car.application.dto;
 import com.wherecar.rest.car.domain.constant.AcquisitionType;
 import com.wherecar.rest.car.domain.constant.CarState;
 import com.wherecar.rest.car.domain.constant.OwnerType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Setter
 @Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/carlog/application/dto/CarLogDetailResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/application/dto/CarLogDetailResponse.java
@@ -6,7 +6,9 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Data
+@Setter
+@Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/carlog/application/dto/CarLogFilterRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/application/dto/CarLogFilterRequest.java
@@ -1,16 +1,12 @@
 package com.wherecar.rest.carlog.application.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Data
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@Setter
+@Getter
+@ToString
 public class CarLogFilterRequest {
     private String mdn;
     private LocalDateTime startTime;

--- a/rest/src/main/java/com/wherecar/rest/carlog/application/dto/CarLogResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/application/dto/CarLogResponse.java
@@ -2,15 +2,14 @@ package com.wherecar.rest.carlog.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.wherecar.rest.carlog.domain.constant.DriveType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
+@Setter
 @Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/carlog/application/dto/CarLogsUpdateRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/application/dto/CarLogsUpdateRequest.java
@@ -3,10 +3,9 @@ package com.wherecar.rest.carlog.application.dto;
 import com.wherecar.rest.carlog.domain.constant.DriveType;
 import lombok.*;
 
-@Data
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@Setter
+@Getter
+@ToString
 public class CarLogsUpdateRequest {
 
     private String driver;

--- a/rest/src/main/java/com/wherecar/rest/carlog/application/dto/MonthlyMileage.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/application/dto/MonthlyMileage.java
@@ -1,11 +1,10 @@
 package com.wherecar.rest.carlog.application.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Setter
 @Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/application/dto/CarLogSummaryOverviewResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/application/dto/CarLogSummaryOverviewResponse.java
@@ -1,14 +1,13 @@
 package com.wherecar.rest.carlogsummary.application.dto;
 
 import com.wherecar.rest.gpslog.application.dto.GpsPoint;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
-@Data
+@Setter
+@Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/company/application/dto/CompanyRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/company/application/dto/CompanyRequest.java
@@ -3,10 +3,9 @@ package com.wherecar.rest.company.application.dto;
 
 import lombok.*;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Setter
+@Getter
+@ToString
 public class CompanyRequest {
     private String id;
     private String address;

--- a/rest/src/main/java/com/wherecar/rest/company/application/dto/CompanyResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/company/application/dto/CompanyResponse.java
@@ -1,11 +1,10 @@
 package com.wherecar.rest.company.application.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Setter
 @Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/emulauth/application/dto/EmulTokenRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/emulauth/application/dto/EmulTokenRequest.java
@@ -1,10 +1,12 @@
 package com.wherecar.rest.emulauth.application.dto;
 
 import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
 
+@Setter
 @Getter
-@NoArgsConstructor
+@ToString
 public class EmulTokenRequest {
 
     private String mdn;

--- a/rest/src/main/java/com/wherecar/rest/emulauth/application/dto/EmulTokenResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/emulauth/application/dto/EmulTokenResponse.java
@@ -1,16 +1,19 @@
 package com.wherecar.rest.emulauth.application.dto;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
+@Setter
 @Getter
+@ToString
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class EmulTokenResponse {
 
-    private final String rstCd;
-    private final String rstMsg;
-    private final String mdn;
-    private final String token;
-    private final String exPeriod;
+    private String rstCd;
+    private String rstMsg;
+    private String mdn;
+    private String token;
+    private String exPeriod;
 
 }

--- a/rest/src/main/java/com/wherecar/rest/geoinfo/application/dto/GeoInfoRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/geoinfo/application/dto/GeoInfoRequest.java
@@ -4,10 +4,8 @@ import lombok.*;
 
 import java.time.LocalDateTime;
 
+@Setter
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
 @ToString
 public class GeoInfoRequest {
     private String name;

--- a/rest/src/main/java/com/wherecar/rest/geoinfo/application/dto/GeoInfoResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/geoinfo/application/dto/GeoInfoResponse.java
@@ -1,14 +1,13 @@
 package com.wherecar.rest.geoinfo.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
+@Setter
 @Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/geolog/application/dto/GeoLogRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/geolog/application/dto/GeoLogRequest.java
@@ -2,15 +2,11 @@ package com.wherecar.rest.geolog.application.dto;
 
 import com.wherecar.rest.geoinfo.application.dto.GeoInfoResponse;
 import com.wherecar.rest.gpslog.domain.constant.GpsConditionType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
-@Data
-@Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Setter
+@Getter
+@ToString
 public class GeoLogRequest {
     private Long id;
     private String mdn;

--- a/rest/src/main/java/com/wherecar/rest/geolog/application/dto/GeoLogResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/geolog/application/dto/GeoLogResponse.java
@@ -2,12 +2,11 @@ package com.wherecar.rest.geolog.application.dto;
 
 import com.wherecar.rest.geoinfo.application.dto.GeoInfoResponse;
 import com.wherecar.rest.gpslog.domain.constant.GpsConditionType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+@Setter
 @Getter
+@ToString
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/rest/src/main/java/com/wherecar/rest/gpslog/application/dto/GpsLogRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/gpslog/application/dto/GpsLogRequest.java
@@ -1,16 +1,12 @@
 package com.wherecar.rest.gpslog.application.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
+@Setter
 @Getter
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
+@ToString
 public class GpsLogRequest {
     private String mdn;
     private LocalDateTime startTime;

--- a/rest/src/main/java/com/wherecar/rest/gpslog/application/dto/GpsLogResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/gpslog/application/dto/GpsLogResponse.java
@@ -1,13 +1,16 @@
 package com.wherecar.rest.gpslog.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
+@Setter
 @Getter
+@ToString
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class GpsLogResponse {
     private String mdn;
     private double latitude;

--- a/rest/src/main/java/com/wherecar/rest/gpslog/application/dto/GpsRouteResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/gpslog/application/dto/GpsRouteResponse.java
@@ -1,12 +1,15 @@
 package com.wherecar.rest.gpslog.application.dto;
 
-import lombok.Builder;
-import lombok.Getter;
+import lombok.*;
 
 import java.util.List;
 
+@Setter
 @Getter
+@ToString
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class GpsRouteResponse {
     private String mdn;
     private List<GpsPoint> route;

--- a/rest/src/main/java/com/wherecar/rest/user/application/dto/PasswordRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/user/application/dto/PasswordRequest.java
@@ -1,10 +1,10 @@
 package com.wherecar.rest.user.application.dto;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
-@Data
-@Builder
+@Setter
+@Getter
+@ToString
 public class PasswordRequest {
     String currentPassword;
     String newPassword;

--- a/rest/src/main/java/com/wherecar/rest/user/application/dto/PermissionRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/user/application/dto/PermissionRequest.java
@@ -1,13 +1,13 @@
 package com.wherecar.rest.user.application.dto;
 
 import com.wherecar.rest.user.domain.constant.PermissionType;
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
 import java.util.Set;
 
-@Data
-@Builder
+@Setter
+@Getter
+@ToString
 public class PermissionRequest {
     private Set<PermissionType> permissionTypes;
 }

--- a/rest/src/main/java/com/wherecar/rest/user/application/dto/PermissionResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/user/application/dto/PermissionResponse.java
@@ -1,17 +1,16 @@
 package com.wherecar.rest.user.application.dto;
 
 import com.wherecar.rest.user.domain.constant.PermissionType;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.Set;
 
-@Data
-@NoArgsConstructor
-@AllArgsConstructor
+@Setter
+@Getter
+@ToString
 @Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PermissionResponse {
     private Set<PermissionType> permissionTypes;
 }

--- a/rest/src/main/java/com/wherecar/rest/user/application/dto/RootUserRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/user/application/dto/RootUserRequest.java
@@ -1,9 +1,13 @@
 package com.wherecar.rest.user.application.dto;
 
 import com.wherecar.rest.company.application.dto.CompanyRequest;
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@Data
+@Setter
+@Getter
+@ToString
 public class RootUserRequest {
     private UserRequest user;
     private CompanyRequest company;

--- a/rest/src/main/java/com/wherecar/rest/user/application/dto/SubUserRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/user/application/dto/SubUserRequest.java
@@ -1,10 +1,10 @@
 package com.wherecar.rest.user.application.dto;
 
-import lombok.Builder;
-import lombok.Data;
+import lombok.*;
 
-@Data
-@Builder
+@Setter
+@Getter
+@ToString
 public class SubUserRequest {
     PermissionRequest permission;
     UserRequest user;

--- a/rest/src/main/java/com/wherecar/rest/user/application/dto/UserLoginRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/user/application/dto/UserLoginRequest.java
@@ -1,8 +1,12 @@
 package com.wherecar.rest.user.application.dto;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@Data
+@Setter
+@Getter
+@ToString
 public class UserLoginRequest {
     private String email;
     private String password;

--- a/rest/src/main/java/com/wherecar/rest/user/application/dto/UserRequest.java
+++ b/rest/src/main/java/com/wherecar/rest/user/application/dto/UserRequest.java
@@ -1,8 +1,12 @@
 package com.wherecar.rest.user.application.dto;
 
-import lombok.Data;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
-@Data
+@Setter
+@Getter
+@ToString
 public class UserRequest {
     private String name;
     private String email;

--- a/rest/src/main/java/com/wherecar/rest/user/application/dto/UserResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/user/application/dto/UserResponse.java
@@ -1,17 +1,16 @@
 package com.wherecar.rest.user.application.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
-@Data
+@Setter
+@Getter
+@ToString
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
+@NoArgsConstructor
 public class UserResponse {
     private Long userId;
     private String name;


### PR DESCRIPTION
close #211

# 🔀 Pull Request: DTO 일관성 리팩토링

## 📌 PR 제목  
[#211] refactor: dto 일관적으로 request 랑 response

## 🛠 변경 목적  
- DTO 클래스 전반에 걸쳐 Lombok 어노테이션 사용을 일관되게 정리함
- 불필요하거나 중복된 `@Data`, `@Setter`, `@Getter` 등의 사용을 정리하여 가독성 및 유지보수성 향상
- DTO 내부 `final` 필드와 `@Builder`의 충돌 해결
- 각 DTO의 목적에 맞게 필요한 어노테이션만 명시적으로 사용

## 📂 주요 변경 파일 (일부 예시)

| 파일 경로 | 변경 전 어노테이션 | 변경 후 어노테이션 |
|-----------|------------------|------------------|
| `AnnouncementRequest.java` | `@Setter @Getter @Builder @AllArgsConstructor @NoArgsConstructor @ToString` | 동일 유지 |
| `CarOverviewResponse.java` | `@Data @Setter @Getter @ToString` | `@Setter @Getter @ToString` |
| `CarLogFilterRequest.java` | `@Data @Builder @AllArgsConstructor @NoArgsConstructor @Setter @Getter @ToString` | `@Setter @Getter @Builder @AllArgsConstructor @NoArgsConstructor @ToString` |
| `CompanyRequest.java` | `@Data @Builder @NoArgsConstructor @AllArgsConstructor` | `@Setter @Getter @Builder @NoArgsConstructor @AllArgsConstructor @ToString` |
| `EmulTokenResponse.java` | `@Getter @Builder @AllArgsConstructor @NoArgsConstructor` (with `final` fields) | `@Setter @Getter @Builder @AllArgsConstructor @NoArgsConstructor` (non-final) |

## ✅ 변경 요약  
- `@Data` 제거 → 필요한 어노테이션만 명시
- DTO에 포함된 필드 및 용도에 따라 `@ToString`, `@Builder`, 생성자 관련 어노테이션만 최소화하여 적용
- 중복 제거 및 일관성 있는 어노테이션 적용

## ✨ 기대 효과
- DTO 어노테이션 구성 일관화
- 유지보수 및 협업 시 불필요한 의존성 제거
- Swagger / API 문서 명세 시 불필요한 필드 노출 방지 가능

## 🔍 검토 포인트
- 빌드 및 테스트 정상 동작 여부
- DTO 변경이 API 응답 형식에 영향 주지 않는지 확인 필요
- Swagger 문서 반영 결과 확인 필요

