### PR TITLE
[#214] fix: hub -> emulator return값 전달

### DIFF
--- a/hub/src/main/java/com/wherecar/hub/carlog/persentation/CarLogHubController.java
+++ b/hub/src/main/java/com/wherecar/hub/carlog/persentation/CarLogHubController.java
@@ -2,9 +2,11 @@ package com.wherecar.hub.carlog.persentation;
 
 import com.wherecar.hub.carlog.application.CarLogHubService;
 import com.wherecar.hub.carlog.application.dto.CarLogRequest;
+import com.wherecar.hub.carlog.application.dto.CarLogResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,17 +21,18 @@ public class CarLogHubController {
     private final CarLogHubService carLogHubService;
 
     @PostMapping("/on")
-    public void sendOnLogMessage(@RequestBody @Valid CarLogRequest onLogRequest) {
+    public ResponseEntity<CarLogResponse> sendOnLogMessage(@RequestBody @Valid CarLogRequest onLogRequest) {
         carLogHubService.sendCarOnLogMessage(onLogRequest);
 
-        // todo: return 수정예정 -> redis 토큰 검증 결과
+        return ResponseEntity.ok(CarLogResponse.getCarLogResponse(onLogRequest.getMdn()));
+
     }
 
     @PostMapping("/off")
-    public void sendOffLogMessage(@RequestBody @Valid CarLogRequest offLogRequest) {
+    public ResponseEntity<CarLogResponse> sendOffLogMessage(@RequestBody @Valid CarLogRequest offLogRequest) {
         carLogHubService.sendCarOffLogMessage(offLogRequest);
 
-        // todo: reuturn 수정예정 -> redis 토큰 검증 결과
+        return ResponseEntity.ok(CarLogResponse.getCarLogResponse(offLogRequest.getMdn()));
     }
 
 }

--- a/hub/src/main/java/com/wherecar/hub/gpslog/persentation/GpsLogHubController.java
+++ b/hub/src/main/java/com/wherecar/hub/gpslog/persentation/GpsLogHubController.java
@@ -2,9 +2,11 @@ package com.wherecar.hub.gpslog.persentation;
 
 import com.wherecar.hub.gpslog.application.GpsLogHubService;
 import com.wherecar.hub.gpslog.application.dto.GpsLogRequest;
+import com.wherecar.hub.gpslog.application.dto.GpsLogResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,8 +21,8 @@ public class GpsLogHubController {
     private final GpsLogHubService gpsLogHubService;
 
     @PostMapping("/gps")
-    public void sendGpsLogMessage(@RequestBody @Valid GpsLogRequest gpsLogRequest) {
+    public ResponseEntity<GpsLogResponse> sendGpsLogMessage(@RequestBody @Valid GpsLogRequest gpsLogRequest) {
         gpsLogHubService.sendGpsLogMessage(gpsLogRequest);
-        // todo: return 수정예정 -> redis 토큰 검증 결과
+        return ResponseEntity.ok(GpsLogResponse.getGpsLogResponse(gpsLogRequest.getMdn()));
     }
 }


### PR DESCRIPTION
close #214 

[#214] fix: hub -> emulator return 값 전달

## 📝 작업 내용

> return void -> return ResponseEntity.ok(xxxLogResponse.getxxxLogResponse(xxxLogResquest.getMdn()); 변경

> emulator에 반환값을 전달해 줌으로서 emulator에서 hub에 재요청을 하지 않도록 합니다.
