### PR TITLE
[#251] fix: 대시보드 차트 오류 해결

### DIFF
--- a/rest/src/main/java/com/wherecar/rest/carlog/application/CarLogServiceImpl.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/application/CarLogServiceImpl.java
@@ -125,7 +125,7 @@ public class CarLogServiceImpl implements CarLogService {
 
         // 총 주행 거리 계산
         double totalMileage = currentMonthLogs.stream()
-                .mapToDouble(log -> log.getOffMileage() - log.getOnMileage())
+                .mapToDouble(log -> log.getOffMileage() != null ? log.getOffMileage() - log.getOnMileage() : 0.0)
                 .sum();
 
         // 최근 6개월간 총 주행거리 계산


### PR DESCRIPTION
close #251

## [#251] fix: 대시보드 차트 오류 해결

### 📌 변경 사항
- `CarLogServiceImpl#getAllCarLogsStatics` 내 주행 거리 계산 로직에서 `offMileage`가 `null`인 경우 `NullPointerException`이 발생할 수 있는 문제를 수정했습니다.
- 삼항 연산자를 사용해 `offMileage`가 `null`일 경우 `0.0`으로 처리하도록 변경했습니다.

```java
// before
.mapToDouble(log -> log.getOffMileage() - log.getOnMileage())

// after
.mapToDouble(log -> log.getOffMileage() != null ? log.getOffMileage() - log.getOnMileage() : 0.0)

