### PR TITLE
[#257] feat: 권한 검증 추가

### DIFF
--- a/collector/src/main/java/com/wherecar/collector/carlog/infrastructure/CarLogStoreImpl.java
+++ b/collector/src/main/java/com/wherecar/collector/carlog/infrastructure/CarLogStoreImpl.java
@@ -32,15 +32,19 @@ public class CarLogStoreImpl implements CarLogStore {
     @Override
     public void storeOnLog(CarLogRequest onLogRequest, Car car, CarLog previousCarLog, CarLog carLog) {
 
-        // 시동 ON 시 최초 누적 거리 != 직전 시동 OFF일 때의 누적 거리
-        if (!CarLog.isSameOffSum(previousCarLog.getOffSum(), onLogRequest.getSum())) {
-            log.error("(시동 ON 시 최초 누적 거리) != (직전 시동 OFF일 때의 누적 거리)");
+//        // 시동 ON 시 최초 누적 거리 != 직전 시동 OFF일 때의 누적 거리
+//        if (!CarLog.isSameOffSum(previousCarLog.getOffSum(), onLogRequest.getSum())) {
+//            log.error("(시동 ON 시 최초 누적 거리) != (직전 시동 OFF일 때의 누적 거리)");
+//
+//        } else { // 시동 ON 시 최초 누적 거리 == 직전 시동 OFF일 때의 누적 거리
+//            carLogRepository.save(carLog);
+//
+//            carStatusRepository.updateCarState(car.getId(), CarState.RUNNING);
+//        }
 
-        } else { // 시동 ON 시 최초 누적 거리 == 직전 시동 OFF일 때의 누적 거리
-            carLogRepository.save(carLog);
+        carLogRepository.save(carLog);
 
-            carStatusRepository.updateCarState(car.getId(), CarState.RUNNING);
-        }
+        carStatusRepository.updateCarState(car.getId(), CarState.RUNNING);
     }
 
     @Override

--- a/rest/src/main/java/com/wherecar/rest/car/presentation/CarController.java
+++ b/rest/src/main/java/com/wherecar/rest/car/presentation/CarController.java
@@ -6,6 +6,8 @@ import com.wherecar.rest.car.application.dto.CarRegisterRequest;
 import com.wherecar.rest.car.application.dto.CarResponse;
 import com.wherecar.rest.common.constants.PaginationConstants;
 import com.wherecar.rest.common.response.BaseResponse;
+import com.wherecar.rest.security.aspect.RequiredPermission;
+import com.wherecar.rest.user.domain.constant.PermissionType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -24,26 +26,28 @@ public class CarController {
 
     private final CarService carService;
 
-
+    @RequiredPermission(PermissionType.PERM_VEHICLE_ADD)
     @PostMapping
     public ResponseEntity<BaseResponse<CarResponse>> CarCreate(HttpServletRequest request, @RequestBody @Valid CarRegisterRequest registerCarRequest) {
         Long companyId = (Long)request.getAttribute("companyId");
         CarResponse carResponse = carService.createCar(companyId, registerCarRequest);
         return BaseResponse.created(carResponse);
     }
-
+    @RequiredPermission(PermissionType.PERM_VEHICLE_EDIT)
     @PutMapping("/{id}")
     public ResponseEntity<BaseResponse<CarResponse>> CarUpdate(@PathVariable Long id, @RequestBody @Valid CarRegisterRequest registerCarRequest) {
         CarResponse carResponse = carService.updateCar(id, registerCarRequest);
         return BaseResponse.created(carResponse);
     }
 
+    @RequiredPermission(PermissionType.PERM_VEHICLE_DELETE)
     @DeleteMapping("/{id}")
     public ResponseEntity<BaseResponse<Void>> CarDelete(@PathVariable Long id) {
         carService.deleteCar(id);
         return BaseResponse.ok();
     }
 
+    @RequiredPermission(PermissionType.PERM_VEHICLE_VIEW)
     @GetMapping
     public ResponseEntity<BaseResponse<List<CarResponse>>> CarsGetAll(
             HttpServletRequest request,
@@ -56,11 +60,13 @@ public class CarController {
         return BaseResponse.ok(cars);
     }
 
+    @RequiredPermission(PermissionType.PERM_VEHICLE_VIEW)
     @GetMapping("/{id}")
     public ResponseEntity<BaseResponse<CarResponse>> CarGetDetails(@PathVariable Long id) {
         CarResponse carResponse = carService.getCarDetails(id);
         return BaseResponse.ok(carResponse);
     }
+
 
     //정보별 차량 수 반환
     @GetMapping("/overview")

--- a/rest/src/main/java/com/wherecar/rest/carlog/presentation/CarLogController.java
+++ b/rest/src/main/java/com/wherecar/rest/carlog/presentation/CarLogController.java
@@ -7,6 +7,8 @@ import com.wherecar.rest.carlog.application.dto.MonthlyMileage;
 import com.wherecar.rest.carlog.domain.constant.DriveType;
 import com.wherecar.rest.common.constants.PaginationConstants;
 import com.wherecar.rest.common.response.BaseResponse;
+import com.wherecar.rest.security.aspect.RequiredPermission;
+import com.wherecar.rest.user.domain.constant.PermissionType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +34,7 @@ class CarLogController {
     private final CarLogService carLogService;
 
     //운행일지 목록 조회 (filter 추가)
+    @RequiredPermission(PermissionType.PERM_LOGS_VIEW)
     @GetMapping
     public ResponseEntity<BaseResponse<Page<CarLogResponse>>> carLogsGetWithFilter(
             HttpServletRequest httpServletRequest,
@@ -63,6 +66,7 @@ class CarLogController {
     }
 
     //운행일지 상세 정보 조회
+    @RequiredPermission(PermissionType.PERM_LOGS_VIEW)
     @GetMapping("/{logId}")
     public ResponseEntity<BaseResponse<CarLogResponse>> carLogsGetDetails(@PathVariable Long logId) {
         CarLogResponse carLogs = carLogService.getCarLogDetails(logId);
@@ -70,6 +74,7 @@ class CarLogController {
     }
 
     //운행일지 상세 정보 수정
+    @RequiredPermission(PermissionType.PERM_LOGS_EDIT)
     @PutMapping("/{logId}")
     public ResponseEntity<BaseResponse<CarLogResponse>> carLogUpdateDetails(@PathVariable Long logId, @RequestBody CarLogsUpdateRequest carLogsUpdateRequest) {
         CarLogResponse carLogResponse = carLogService.updateCarLogDetails(logId, carLogsUpdateRequest);
@@ -78,6 +83,7 @@ class CarLogController {
 
 
     //운행일지 상세 정보 삭제
+    @RequiredPermission(PermissionType.PERM_LOGS_DELETE)
     @DeleteMapping("/{logId}")
     public ResponseEntity<BaseResponse<Void>> carLogDeleteDetails(@PathVariable Long logId) {
         carLogService.deleteCarLogDetails(logId);

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/presentation/CarLogSummaryController.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/presentation/CarLogSummaryController.java
@@ -3,6 +3,8 @@ package com.wherecar.rest.carlogsummary.presentation;
 import com.wherecar.rest.carlogsummary.application.CarLogSummaryService;
 import com.wherecar.rest.carlogsummary.application.dto.CarLogSummaryOverviewResponse;
 import com.wherecar.rest.common.response.BaseResponse;
+import com.wherecar.rest.security.aspect.RequiredPermission;
+import com.wherecar.rest.user.domain.constant.PermissionType;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,6 +27,7 @@ import java.time.format.DateTimeFormatter;
 public class CarLogSummaryController {
     private final CarLogSummaryService carLogSummaryService;
 
+    @RequiredPermission(PermissionType.PERM_STATS_VIEW)
     @GetMapping("/companies/my")
     public ResponseEntity<BaseResponse<CarLogSummaryOverviewResponse>> carLogSummaryOverviewGetByCompanyId(HttpServletRequest request, @RequestParam String from, @RequestParam String to) {
         Long companyId = (Long)request.getAttribute("companyId");
@@ -39,6 +42,7 @@ public class CarLogSummaryController {
         return BaseResponse.ok(overviewResponse);
     }
 
+    @RequiredPermission(PermissionType.PERM_STATS_VIEW)
     @GetMapping("/mdn")
     public ResponseEntity<BaseResponse<CarLogSummaryOverviewResponse>> carLogSummaryOverviewGetByMdn(@RequestParam String mdn, @RequestParam String from, @RequestParam String to) {
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd");

--- a/rest/src/main/java/com/wherecar/rest/common/exception/GlobalExceptionHandler.java
+++ b/rest/src/main/java/com/wherecar/rest/common/exception/GlobalExceptionHandler.java
@@ -3,6 +3,7 @@ package com.wherecar.rest.common.exception;
 import com.wherecar.rest.common.response.BaseResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -19,6 +20,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<BaseResponse<Void>> handleException(Exception e) {
 
         return BaseResponse.badRequest(e.getMessage());
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<BaseResponse<Void>> handleException(AccessDeniedException e) {
+        return BaseResponse.forbidden(e.getMessage());
     }
 
     @ExceptionHandler

--- a/rest/src/main/java/com/wherecar/rest/company/presentation/CompanyController.java
+++ b/rest/src/main/java/com/wherecar/rest/company/presentation/CompanyController.java
@@ -4,6 +4,8 @@ import com.wherecar.rest.common.response.BaseResponse;
 import com.wherecar.rest.company.application.CompanyService;
 import com.wherecar.rest.company.application.dto.CompanyRequest;
 import com.wherecar.rest.company.application.dto.CompanyResponse;
+import com.wherecar.rest.security.aspect.RequiredPermission;
+import com.wherecar.rest.user.domain.constant.PermissionType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +23,7 @@ public class CompanyController {
 
     private final CompanyService companyService;
 
-
+    @RequiredPermission(PermissionType.PERM_COMPANY_VIEW)
     @GetMapping("/my")
     public ResponseEntity<BaseResponse<CompanyResponse>> myCompanyDetailsGet(HttpServletRequest request) {
         Long companyId = (Long)request.getAttribute("companyId");
@@ -29,6 +31,8 @@ public class CompanyController {
         return BaseResponse.ok(companyResponse);
     }
 
+
+    @RequiredPermission(PermissionType.PERM_COMPANY_EDIT)
     @PutMapping("/my")
     public ResponseEntity<BaseResponse<CompanyResponse>> myCompanyUpdate(HttpServletRequest request, @RequestBody @Valid CompanyRequest companyRequest) {
         Long companyId = (Long)request.getAttribute("companyId");

--- a/rest/src/main/java/com/wherecar/rest/security/aspect/PermissionCheckAspect.java
+++ b/rest/src/main/java/com/wherecar/rest/security/aspect/PermissionCheckAspect.java
@@ -8,6 +8,7 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.core.annotation.Order;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 
 import java.util.Set;
@@ -24,7 +25,7 @@ public class PermissionCheckAspect {
     @Around("@annotation(requiredPermission)")
     public Object checkPermissions(ProceedingJoinPoint joinPoint, RequiredPermission requiredPermission) throws Throwable {
         @SuppressWarnings("unchecked")
-        Set<PermissionType> userPermissions = (Set<PermissionType>) request.getAttribute("PermissionTypes");
+        Set<PermissionType> userPermissions = (Set<PermissionType>) request.getAttribute("permissionTypes");
 
         PermissionType[] requiredPermissions = requiredPermission.value();
 
@@ -38,6 +39,6 @@ public class PermissionCheckAspect {
             }
         }
 
-        throw new RuntimeException("No Permission found for required permission: " + requiredPermission);
+        throw new AccessDeniedException("필요한 권한이 없습니다: " + requiredPermission);
     }
 }

--- a/rest/src/main/java/com/wherecar/rest/user/domain/constant/PermissionType.java
+++ b/rest/src/main/java/com/wherecar/rest/user/domain/constant/PermissionType.java
@@ -22,11 +22,15 @@ public enum PermissionType {
 
     // 로그 관련 권한
     PERM_LOGS_VIEW,
-    PERM_LOGS_EXPORT,
+    PERM_LOGS_EDIT,
+    PERM_LOGS_DELETE,
 
     // 대시보드 관련 권한
     PERM_DASHBOARD_VIEW,
     PERM_DASHBOARD_EDIT,
+
+    // 통계
+    PERM_STATS_VIEW,
 
     // 관리자 권한
     PERM_ADMIN

--- a/rest/src/main/java/com/wherecar/rest/user/presentation/UserController.java
+++ b/rest/src/main/java/com/wherecar/rest/user/presentation/UserController.java
@@ -1,8 +1,10 @@
 package com.wherecar.rest.user.presentation;
 
 import com.wherecar.rest.common.response.BaseResponse;
+import com.wherecar.rest.security.aspect.RequiredPermission;
 import com.wherecar.rest.user.application.UserService;
 import com.wherecar.rest.user.application.dto.*;
+import com.wherecar.rest.user.domain.constant.PermissionType;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +29,7 @@ public class UserController {
         return BaseResponse.created(userResponse);
     }
 
-//    @RequiredPermission(PermissionType.SUB_USER_CREATE)
+    @RequiredPermission(PermissionType.PERM_EMPLOYEE_ADD)
     @PostMapping("/sub")
     public ResponseEntity<BaseResponse<UserResponse>> subCreate(HttpServletRequest request, @RequestBody @Valid SubUserRequest subUserRequest) {
         log.info("Creating sub user: {}", subUserRequest);
@@ -35,7 +37,7 @@ public class UserController {
         UserResponse userResponse = userService.createSub(subUserRequest, companyId);
         return BaseResponse.created(userResponse);
     }
-//    @RequiredPermission(PermissionType.USER_VIEW)
+    @RequiredPermission(PermissionType.PERM_EMPLOYEE_VIEW)
     @GetMapping("/companies/my")
     public ResponseEntity<BaseResponse<List<UserResponse>>> usersGetOfCompany(HttpServletRequest request){
         Long companyId = (Long)request.getAttribute("companyId");
@@ -44,7 +46,7 @@ public class UserController {
         return BaseResponse.ok(userResponses);
     }
 
-//    @RequiredPermission(PermissionType.USER_VIEW)
+    @RequiredPermission(PermissionType.PERM_EMPLOYEE_VIEW)
     @GetMapping("/{userId}")
     public ResponseEntity<BaseResponse<UserResponse>> userGet(@PathVariable Long userId){
         log.info("Retrieving user with id: {}", userId);
@@ -52,7 +54,6 @@ public class UserController {
         return BaseResponse.ok(userResponse);
     }
 
-//    @RequiredPermission(PermissionType.USER_VIEW)
     @GetMapping("/my")
     public ResponseEntity<BaseResponse<UserResponse>> myUserGet(HttpServletRequest request){
         Long userId = (Long)request.getAttribute("userId");
@@ -61,7 +62,7 @@ public class UserController {
         return BaseResponse.ok(userResponse);
     }
 
-//    @RequiredPermission(PermissionType.ROOT)
+    @RequiredPermission(PermissionType.PERM_EMPLOYEE_DELETE)
     @DeleteMapping("/{userId}")
     public ResponseEntity<BaseResponse<Void>> userDelete(@PathVariable Long userId){
         log.info("Deleting user with id: {}", userId);
@@ -69,7 +70,6 @@ public class UserController {
         return BaseResponse.ok();
     }
 
-//    @RequiredPermission(PermissionType.ROOT)
     @DeleteMapping("/my")
     public ResponseEntity<BaseResponse<Void>> myUserDelete(HttpServletRequest request){
         Long userId = (Long)request.getAttribute("userId");
@@ -78,7 +78,7 @@ public class UserController {
         return BaseResponse.ok();
     }
 
-//    @RequiredPermission(PermissionType.ROOT)
+    @RequiredPermission(PermissionType.PERM_EMPLOYEE_EDIT)
     @PutMapping("/{userId}")
     public ResponseEntity<BaseResponse<UserResponse>> userUpdate(@PathVariable Long userId, @RequestBody @Valid UserUpdateRequest userRequest){
         log.info("Updating user with id: {}", userId);
@@ -86,7 +86,6 @@ public class UserController {
         return BaseResponse.created(userResponse);
     }
 
-//    @RequiredPermission(PermissionType.ROOT)
     @PutMapping("/my")
     public ResponseEntity<BaseResponse<UserResponse>> myUserUpdate(HttpServletRequest request, @RequestBody @Valid UserUpdateRequest userRequest){
         Long userId = (Long)request.getAttribute("userId");
@@ -95,19 +94,10 @@ public class UserController {
         return BaseResponse.created(userResponse);
     }
 
-//    @RequiredPermission(PermissionType.ROOT)
-    @PutMapping("/password")
-    public ResponseEntity<BaseResponse<UserResponse>> passwordUpdate(HttpServletRequest request, @RequestBody @Valid PasswordRequest passwordRequest){
-        Long userId = (Long)request.getAttribute("userId");
-        log.info("Updating password");
-        UserResponse userResponse = userService.updatePasswordById(userId, passwordRequest);
-        return BaseResponse.created(userResponse);
-    }
-
     //Permission
 
 
-//    @RequiredPermission(PermissionType.ROOT)
+    @RequiredPermission(PermissionType.PERM_PERMISSION_EDIT)
     @PutMapping("/permissions/{userId}")
     public ResponseEntity<BaseResponse<UserResponse>> permissionUpdate(@PathVariable Long userId, @RequestBody PermissionRequest permissionRequest){
         log.info("Adding permission with id: {}", userId);
@@ -115,15 +105,8 @@ public class UserController {
         return BaseResponse.created(userResponse);
     }
 
-    @PutMapping("/permissions/my")
-    public ResponseEntity<BaseResponse<UserResponse>> myPermissionUpdate(HttpServletRequest request, @RequestBody PermissionRequest permissionRequest){
-        Long userId = (Long)request.getAttribute("userId");
-        log.info("Retrieving my permission with id: {}", userId);
-        UserResponse userResponse = userService.updatePermission(userId, permissionRequest);
-        return BaseResponse.created(userResponse);
-    }
 
-//    @RequiredPermission(PermissionType.ROOT)
+    @RequiredPermission(PermissionType.PERM_PERMISSION_VIEW)
     @GetMapping("/permissions/{userId}")
     public ResponseEntity<BaseResponse<PermissionResponse>> permissionGet(@PathVariable Long userId){
         log.info("Retrieving permission with id: {}", userId);

--- a/rest/src/main/resources/sql/permissions.sql
+++ b/rest/src/main/resources/sql/permissions.sql
@@ -1,3 +1,4 @@
+-- 회사 관련 권한
 INSERT INTO permissions (type) VALUES ('PERM_COMPANY_VIEW');
 INSERT INTO permissions (type) VALUES ('PERM_COMPANY_EDIT');
 
@@ -19,12 +20,15 @@ INSERT INTO permissions (type) VALUES ('PERM_VEHICLE_DELETE');
 
 -- 로그 관련 권한
 INSERT INTO permissions (type) VALUES ('PERM_LOGS_VIEW');
-INSERT INTO permissions (type) VALUES ('PERM_LOGS_EXPORT');
+INSERT INTO permissions (type) VALUES ('PERM_LOGS_EDIT');
+INSERT INTO permissions (type) VALUES ('PERM_LOGS_DELETE');
 
 -- 대시보드 관련 권한
 INSERT INTO permissions (type) VALUES ('PERM_DASHBOARD_VIEW');
 INSERT INTO permissions (type) VALUES ('PERM_DASHBOARD_EDIT');
 
+-- 통계 관련 권한
+INSERT INTO permissions (type) VALUES ('PERM_STATS_VIEW');
+
 -- 관리자 권한
 INSERT INTO permissions (type) VALUES ('PERM_ADMIN');
-


### PR DESCRIPTION
close #257

## 변경 내용 요약

- `@RequiredPermission` 어노테이션을 기반으로 하는 권한 체크 AOP(`PermissionCheckAspect`) 구현
- Controller 레벨에서 엔드포인트별 필요한 권한 지정 (`PermissionType`)
- 권한 검증 실패 시 `AccessDeniedException` 처리 추가
- `PermissionType` 항목 보강 (PERM_LOGS_EDIT, PERM_STATS_VIEW 등)
- `permissions.sql`에 권한 항목 추가
- 주석 처리된 기존 `@RequiredPermission`은 일관되게 새로운 PermissionType으로 교체

## 주요 변경 파일
- `PermissionCheckAspect.java`
- `GlobalExceptionHandler.java`
- 각 도메인의 `Controller` 클래스
- `PermissionType.java`
- `permissions.sql`

## 기타
- `request.getAttribute("permissionTypes")` 를 통해 사용자 권한 정보를 받아 처리
- 미인증 사용자 또는 권한 부족 시 403 Forbidden 응답 반환



