### PR TITLE
[#262] modify: 검증 오류 프론트엔드 쪽으로 전달

### DIFF
--- a/rest/src/main/java/com/wherecar/rest/common/exception/GlobalExceptionHandler.java
+++ b/rest/src/main/java/com/wherecar/rest/common/exception/GlobalExceptionHandler.java
@@ -4,10 +4,13 @@ import com.wherecar.rest.common.response.BaseResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.AccessDeniedException;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
 @Slf4j
@@ -29,12 +32,13 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<BaseResponse<Void>> handleValidationExceptions(MethodArgumentNotValidException e) {
-        e.getBindingResult().getAllErrors().forEach(error -> {
-            String errorMessage = error.getDefaultMessage();
-            log.info("Validation 실패: {}", errorMessage);
-        });
 
-        return BaseResponse.badRequest(e.getMessage());
+        Map<String, String> errors = new HashMap<>();
+        for (FieldError error : e.getBindingResult().getFieldErrors()) {
+            errors.put(error.getField(), error.getDefaultMessage());
+        }
+
+        return BaseResponse.validationErrors(errors);
     }
 
 }

--- a/rest/src/main/java/com/wherecar/rest/common/response/BaseResponse.java
+++ b/rest/src/main/java/com/wherecar/rest/common/response/BaseResponse.java
@@ -3,13 +3,19 @@ package com.wherecar.rest.common.response;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import java.util.HashMap;
+import java.util.Map;
+
 @Data
+@Slf4j
 public class BaseResponse<T> {
     private T data;
     private String message;
+    private Map<String, String> errors = new HashMap<>();
     private int statusCode;
 
     private static final ObjectMapper objectMapper = new ObjectMapper();  // ObjectMapper 재사용
@@ -23,6 +29,12 @@ public class BaseResponse<T> {
     public BaseResponse(String message, int statusCode) {
         this.data = null;
         this.message = message;
+        this.statusCode = statusCode;
+    }
+
+    public BaseResponse(Map<String, String> errors, int statusCode) {
+        this.data = null;
+        this.errors = errors;
         this.statusCode = statusCode;
     }
 
@@ -59,6 +71,13 @@ public class BaseResponse<T> {
     }
 
     // ====== 클라이언트 오류 응답 ======
+
+    public static <T> ResponseEntity<BaseResponse<T>> validationErrors(Map<String, String> errors) {
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(new BaseResponse<>(errors, HttpStatus.OK.value()));
+    }
 
     public static <T> ResponseEntity<BaseResponse<T>> badRequest(String message) {
         return ResponseEntity


### PR DESCRIPTION
close #262

## 📝 작업 내용

기존엔 rest에서 validation 검증 실패가 생기면 400 에러가 생겼었는데, 이제 200 OK로 바꾸고 검증 오류 메시지를 프론트엔드 쪽으로 보내도록 바꿨습니다. 모든 에러를 이렇게 바꾼 건 아니고 rest 쪽의 validation 오류만 이런 식으로 처리했습니다.


## 💬 리뷰 요구사항(선택)

제가 프론트엔드 쪽 코드를 몰라서, 지금 이 코드로 프론트엔드에서 검증 오류 메시지를 성공적으로 출력할 수 있는 건지, 이렇게 데이터를 보내는 게 맞는지 잘 모르겠습니다. 확인해 보셨으면 좋겠습니다. 만약 잘 된다면 다른 에러들도 필요하면 이런 식으로 작업해 보겠습니다.

📍 기타 (선택)

기존엔 직원 추가할 때 검증 오류가 발생하면 해당 페이지에서 400 에러가 생겼다고 보여졌었는데
지금 코드로 바꾸고 나니 직원 추가를 성공적으로 했을 때처럼 회사 페이지(업체 정보랑 직원 목록 보이는 화면)로 이동하지만, 직원이 실제로 저장되진 않습니다.
검증 오류가 발생해도 화면 이동이 안 되도록 하는 코드를 프론트엔드 쪽에서 할 수 있는지 궁금합니다.