### PR TITLE
[#272] feat: hub cors 해결

### DIFF
--- a/hub/src/main/java/com/wherecar/hub/config/CorsConfig.java
+++ b/hub/src/main/java/com/wherecar/hub/config/CorsConfig.java
@@ -1,0 +1,16 @@
+package com.wherecar.hub.config;
+
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("https://track.where-car.com")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}


### PR DESCRIPTION
close #272

## 변경 내용
- `com.wherecar.hub.config.CorsConfig` 클래스 추가
- `/api/**` 경로에 대해 CORS 설정 적용
  - 허용 origin: https://track.where-car.com
  - 허용 메서드: GET, POST, PUT, DELETE, OPTIONS
  - credentials 허용 및 모든 헤더 허용

## 목적
- 클라이언트 (https://track.where-car.com)에서 API 호출 시 CORS 오류 방지
- WebSocket 외 REST API 사용 시에도 보안된 접근 허용을 위해 도입

## 참고
- `WebMvcConfigurer` 구현을 통해 스프링 MVC 전역 CORS 설정 적용

