### PR TITLE
[#272] feat: hub cors 해결

### DIFF
--- a/hub/src/main/java/com/wherecar/hub/config/CorsConfig.java
+++ b/hub/src/main/java/com/wherecar/hub/config/CorsConfig.java
@@ -1,0 +1,16 @@
+package com.wherecar.hub.config;
+
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+public class CorsConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/api/**")
+                .allowedOrigins("https://track.where-car.com")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .allowCredentials(true);
+    }
+}

--- a/hub/src/main/java/com/wherecar/hub/config/CorsConfig.java
+++ b/hub/src/main/java/com/wherecar/hub/config/CorsConfig.java
@@ -1,14 +1,19 @@
 package com.wherecar.hub.config;
 
+import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Configuration
 public class CorsConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**")
-                .allowedOrigins("https://track.where-car.com")
+                .allowedOrigins(
+                        "https://track.where-car.com",
+                        "http://localhost:5173"
+                )
                 .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
                 .allowedHeaders("*")
                 .allowCredentials(true);


### PR DESCRIPTION
## Summary
- `CorsConfig` 설정 클래스에서 CORS 허용 도메인에 `http://localhost:5173` 추가
- 기존 `https://track.where-car.com`에 더해, 로컬 개발 환경에서의 테스트 편의성 향상 목적

## Changes
- `allowedOrigins` 메서드 중복 호출 제거
- `allowedOrigins(...)`에 배열 형식으로 두 개의 origin 설정

## Related Issue
- Closes #272

## Checklist
- [x] 로컬에서 http://localhost:5173 도메인 테스트 완료
- [x] 기존 배포 도메인에도 영향 없음 확인
