### PR TITLE
[#287]  feat: 관제 관련 도커 수정 및 ELK, Loki 어펜더등 관련 설정 수정

### DIFF
--- a/batch/src/main/resources/application-dev.yml
+++ b/batch/src/main/resources/application-dev.yml
@@ -32,6 +32,9 @@ spring:
     jdbc:
       initialize-schema: always
 
+server:
+  port: 8095
+
 management:
   endpoints:
     web:
@@ -42,5 +45,11 @@ management:
       application: ${spring.application.name}
       environment: ${spring.profiles.active}
 
-server:
-  port: 8095
+monitoring:
+  loki:
+    host: http://localhost
+    port: 3100
+    endpoint: /loki/api/v1/push
+  logstash:
+    host: localhost
+    port: 5100

--- a/batch/src/main/resources/application-prod.yml
+++ b/batch/src/main/resources/application-prod.yml
@@ -51,4 +51,9 @@ management:
 
 monitoring:
   loki:
-    url: ${LOKI_URL}
+    host: ${LOKI_HOST}
+    post: ${LOKI_PORT}
+    endpoint: ${LOKI_ENDPOINT}
+  logstash:
+    host: ${LOGSTASH_HOST}
+    port: ${LOGSTASH_PORT}

--- a/batch/src/main/resources/logback-spring.xml
+++ b/batch/src/main/resources/logback-spring.xml
@@ -3,7 +3,11 @@
     <!-- 공통 속성 정의 -->
     <springProperty scope="context" name="LOG_FILE_NAME" source="spring.application.name" defaultValue="application"/>
     <springProperty scope="context" name="ACTIVE_PROFILE" source="spring.profiles.active" defaultValue="dev"/>
-    <springProperty scope="context" name="LOKI_URL" source="monitoring.loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+    <springProperty scope="context" name="LOKI_HOST" source="monitoring.loki.host" defaultValue="http://localhost"/>
+    <springProperty scope="context" name="LOKI_PORT" source="monitoring.loki.port" defaultValue="3100"/>
+    <springProperty scope="context" name="LOKI_ENDPOINT" source="monitoring.loki.endpoint" defaultValue="/loki/api/v1/push"/>
+    <springProperty scope="context" name="LOGSTASH_HOST" source="monitoring.logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="LOGSTASH_PORT" source="monitoring.logstash.port" defaultValue="5044"/>
     <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}][%-5level][%logger{36}][%method] %msg | %X{params} %n" />
     <property name="LOG_PATTERN_COLOR" value="%magenta([%d{yyyy-MM-dd HH:mm:ss}]) %highlight([%-5level]) %green([%logger{36}]) %yellow([%method]) %msg | %X{params} %n" />
 
@@ -15,39 +19,63 @@
         </encoder>
     </appender>
 
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_HOST}:${LOKI_PORT}${LOKI_ENDPOINT}</url>
+            <connectionTimeoutMs>5000</connectionTimeoutMs>
+            <requestTimeoutMs>10000</requestTimeoutMs>
+        </http>
+        <format>
+            <label>
+                <pattern>app=${LOG_FILE_NAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
+            </label>
+            <message>
+                <pattern>${LOG_PATTERN}</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+        <primarySwitch>
+            <disableOnError>true</disableOnError>
+            <silentFallback>true</silentFallback>
+        </primarySwitch>
+        <verbose>false</verbose> // Debugging mode
+        <metricsEnabled>true</metricsEnabled>
+        <batchSize>1000</batchSize>
+        <batchTimeoutMs>10000</batchTimeoutMs>
+        <drainOnStop>true</drainOnStop>
+        <retryCount>3</retryCount>
+        <waitBetweenRetries>2000</waitBetweenRetries>
+    </appender>
+
+    <!-- Logstash Appender (공식 권장 설정) -->
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${LOGSTASH_HOST}:${LOGSTASH_PORT}</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"app":"${LOG_FILE_NAME}","env":"${ACTIVE_PROFILE}","service":"where-car"}</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <shortenedLoggerNameLength>36</shortenedLoggerNameLength>
+            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                <maxLength>4096</maxLength>
+                <shortenedClassNameLength>36</shortenedClassNameLength>
+                <rootCauseFirst>true</rootCauseFirst>
+            </throwableConverter>
+        </encoder>
+        <reconnectionDelay>1 second</reconnectionDelay>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
+        <connectionStrategy>
+            <roundRobin>
+                <connectionTTL>5 minutes</connectionTTL>
+            </roundRobin>
+        </connectionStrategy>
+    </appender>
+
     <!-- 개발 환경 설정 -->
     <springProfile name="dev">
         <!-- 개발 환경 속성 -->
         <property name="LOG_PATH" value="logs" />
         <property name="LOG_LEVEL" value="DEBUG" />
-
-        <!-- Loki Appender 설정 (개발 환경) -->
-        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-            <http>
-                <url>${LOKI_URL}</url>
-                <connectionTimeoutMs>5000</connectionTimeoutMs>
-                <requestTimeoutMs>10000</requestTimeoutMs>
-            </http>
-            <format>
-                <label>
-                    <pattern>app=${LOG_FILE_NAME},host=${HOSTNAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
-                </label>
-                <message>
-                    <pattern>${LOG_PATTERN}</pattern>
-                </message>
-                <sortByTime>true</sortByTime>
-            </format>
-            <primarySwitch>
-                <disableOnError>true</disableOnError>
-                <silentFallback>true</silentFallback>
-            </primarySwitch>
-            <verbose>false</verbose>
-            <metricsEnabled>true</metricsEnabled>
-            <batchSize>100</batchSize>
-            <batchTimeoutMs>10000</batchTimeoutMs>
-            <retryCount>2</retryCount>
-            <waitBetweenRetries>1000</waitBetweenRetries>
-        </appender>
 
         <!-- 개발 환경: 활성 로그는 logs/앱이름/앱이름-info.log, 롤링 시 logs/앱이름/날짜/앱이름-info.log -->
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -96,23 +124,27 @@
             <appender-ref ref="FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="com.wherecar.error" level="ERROR" additivity="false">
             <appender-ref ref="ERROR_FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 개발 환경 SQL 로깅 - 모든 SQL 쿼리 기록 -->
         <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
             <appender-ref ref="QUERY_FILE" />
             <appender-ref ref="CONSOLE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="org.hibernate.type.descriptor.sql" level="TRACE" additivity="false">
             <appender-ref ref="QUERY_FILE" />
             <appender-ref ref="CONSOLE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 개발 환경 루트 로거 - 상세 로깅 -->
@@ -120,6 +152,7 @@
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="FILE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </root>
     </springProfile>
 
@@ -131,35 +164,6 @@
         
         <!-- JSON 형식 로그 패턴 (ELK 분석용) -->
         <property name="LOG_PATTERN_JSON" value="{&quot;timestamp&quot;:&quot;%d{yyyy-MM-dd HH:mm:ss.SSS}&quot;,&quot;level&quot;:&quot;%level&quot;,&quot;thread&quot;:&quot;%thread&quot;,&quot;logger&quot;:&quot;%logger{36}&quot;,&quot;method&quot;:&quot;%method&quot;,&quot;message&quot;:&quot;%message&quot;,&quot;params&quot;:&quot;%X{params}&quot;}%n" />
-
-        <!-- Loki Appender 설정 (운영 환경) -->
-        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-            <http>
-                <url>${LOKI_URL}</url>
-                <connectionTimeoutMs>5000</connectionTimeoutMs>
-                <requestTimeoutMs>10000</requestTimeoutMs>
-            </http>
-            <format>
-                <label>
-                    <pattern>app=${LOG_FILE_NAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
-                </label>
-                <message>
-                    <pattern>${LOG_PATTERN}</pattern>
-                </message>
-                <sortByTime>true</sortByTime>
-            </format>
-            <primarySwitch>
-                <disableOnError>true</disableOnError>
-                <silentFallback>true</silentFallback>
-            </primarySwitch>
-            <verbose>true</verbose>
-            <metricsEnabled>true</metricsEnabled>
-            <batchSize>1000</batchSize>
-            <batchTimeoutMs>10000</batchTimeoutMs>
-            <drainOnStop>true</drainOnStop>
-            <retryCount>3</retryCount>
-            <waitBetweenRetries>2000</waitBetweenRetries>
-        </appender>
 
         <!-- 운영 환경: 활성 로그는 logs/앱이름-info.log, 롤링 시 logs/날짜/앱이름-info.log -->
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -212,17 +216,20 @@
             <appender-ref ref="FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="com.wherecar.error" level="ERROR" additivity="false">
             <appender-ref ref="ERROR_FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 운영 환경 SQL 로깅 - 필수 SQL 쿼리만 기록 -->
         <logger name="org.hibernate.SQL" level="INFO">
             <appender-ref ref="QUERY_FILE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 운영 환경 루트 로거 - 간결한 로깅 -->
@@ -230,6 +237,7 @@
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="FILE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </root>
     </springProfile>
 

--- a/collector/src/main/resources/application-dev.yml
+++ b/collector/src/main/resources/application-dev.yml
@@ -28,3 +28,12 @@ management:
     tags:
       application: ${spring.application.name}
       environment: ${spring.profiles.active}
+
+monitoring:
+  loki:
+    host: http://localhost
+    port: 3100
+    endpoint: /loki/api/v1/push
+  logstash:
+    host: localhost
+    port: 5100

--- a/collector/src/main/resources/application-prod.yml
+++ b/collector/src/main/resources/application-prod.yml
@@ -35,4 +35,9 @@ management:
 
 monitoring:
   loki:
-    url: ${LOKI_URL}
+    host: ${LOKI_HOST}
+    post: ${LOKI_PORT}
+    endpoint: ${LOKI_ENDPOINT}
+  logstash:
+    host: ${LOGSTASH_HOST}
+    port: ${LOGSTASH_PORT}

--- a/collector/src/main/resources/logback-spring.xml
+++ b/collector/src/main/resources/logback-spring.xml
@@ -3,7 +3,11 @@
     <!-- 공통 속성 정의 -->
     <springProperty scope="context" name="LOG_FILE_NAME" source="spring.application.name" defaultValue="application"/>
     <springProperty scope="context" name="ACTIVE_PROFILE" source="spring.profiles.active" defaultValue="dev"/>
-    <springProperty scope="context" name="LOKI_URL" source="monitoring.loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+    <springProperty scope="context" name="LOKI_HOST" source="monitoring.loki.host" defaultValue="http://localhost"/>
+    <springProperty scope="context" name="LOKI_PORT" source="monitoring.loki.port" defaultValue="3100"/>
+    <springProperty scope="context" name="LOKI_ENDPOINT" source="monitoring.loki.endpoint" defaultValue="/loki/api/v1/push"/>
+    <springProperty scope="context" name="LOGSTASH_HOST" source="monitoring.logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="LOGSTASH_PORT" source="monitoring.logstash.port" defaultValue="5044"/>
     <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}][%-5level][%logger{36}][%method] %msg | %X{params} %n" />
     <property name="LOG_PATTERN_COLOR" value="%magenta([%d{yyyy-MM-dd HH:mm:ss}]) %highlight([%-5level]) %green([%logger{36}]) %yellow([%method]) %msg | %X{params} %n" />
 
@@ -15,39 +19,63 @@
         </encoder>
     </appender>
 
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_HOST}:${LOKI_PORT}${LOKI_ENDPOINT}</url>
+            <connectionTimeoutMs>5000</connectionTimeoutMs>
+            <requestTimeoutMs>10000</requestTimeoutMs>
+        </http>
+        <format>
+            <label>
+                <pattern>app=${LOG_FILE_NAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
+            </label>
+            <message>
+                <pattern>${LOG_PATTERN}</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+        <primarySwitch>
+            <disableOnError>true</disableOnError>
+            <silentFallback>true</silentFallback>
+        </primarySwitch>
+        <verbose>false</verbose> // Debugging mode
+        <metricsEnabled>true</metricsEnabled>
+        <batchSize>1000</batchSize>
+        <batchTimeoutMs>10000</batchTimeoutMs>
+        <drainOnStop>true</drainOnStop>
+        <retryCount>3</retryCount>
+        <waitBetweenRetries>2000</waitBetweenRetries>
+    </appender>
+
+    <!-- Logstash Appender (공식 권장 설정) -->
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${LOGSTASH_HOST}:${LOGSTASH_PORT}</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"app":"${LOG_FILE_NAME}","env":"${ACTIVE_PROFILE}","service":"where-car"}</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <shortenedLoggerNameLength>36</shortenedLoggerNameLength>
+            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                <maxLength>4096</maxLength>
+                <shortenedClassNameLength>36</shortenedClassNameLength>
+                <rootCauseFirst>true</rootCauseFirst>
+            </throwableConverter>
+        </encoder>
+        <reconnectionDelay>1 second</reconnectionDelay>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
+        <connectionStrategy>
+            <roundRobin>
+                <connectionTTL>5 minutes</connectionTTL>
+            </roundRobin>
+        </connectionStrategy>
+    </appender>
+
     <!-- 개발 환경 설정 -->
     <springProfile name="dev">
         <!-- 개발 환경 속성 -->
         <property name="LOG_PATH" value="logs" />
         <property name="LOG_LEVEL" value="DEBUG" />
-
-        <!-- Loki Appender 설정 (개발 환경) -->
-        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-            <http>
-                <url>${LOKI_URL}</url>
-                <connectionTimeoutMs>5000</connectionTimeoutMs>
-                <requestTimeoutMs>10000</requestTimeoutMs>
-            </http>
-            <format>
-                <label>
-                    <pattern>app=${LOG_FILE_NAME},host=${HOSTNAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
-                </label>
-                <message>
-                    <pattern>${LOG_PATTERN}</pattern>
-                </message>
-                <sortByTime>true</sortByTime>
-            </format>
-            <primarySwitch>
-                <disableOnError>true</disableOnError>
-                <silentFallback>true</silentFallback>
-            </primarySwitch>
-            <verbose>false</verbose>
-            <metricsEnabled>true</metricsEnabled>
-            <batchSize>100</batchSize>
-            <batchTimeoutMs>10000</batchTimeoutMs>
-            <retryCount>2</retryCount>
-            <waitBetweenRetries>1000</waitBetweenRetries>
-        </appender>
 
         <!-- 개발 환경: 활성 로그는 logs/앱이름/앱이름-info.log, 롤링 시 logs/앱이름/날짜/앱이름-info.log -->
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -96,23 +124,27 @@
             <appender-ref ref="FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="com.wherecar.error" level="ERROR" additivity="false">
             <appender-ref ref="ERROR_FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 개발 환경 SQL 로깅 - 모든 SQL 쿼리 기록 -->
         <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
             <appender-ref ref="QUERY_FILE" />
             <appender-ref ref="CONSOLE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="org.hibernate.type.descriptor.sql" level="TRACE" additivity="false">
             <appender-ref ref="QUERY_FILE" />
             <appender-ref ref="CONSOLE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 개발 환경 루트 로거 - 상세 로깅 -->
@@ -120,6 +152,7 @@
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="FILE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </root>
     </springProfile>
 
@@ -131,35 +164,6 @@
         
         <!-- JSON 형식 로그 패턴 (ELK 분석용) -->
         <property name="LOG_PATTERN_JSON" value="{&quot;timestamp&quot;:&quot;%d{yyyy-MM-dd HH:mm:ss.SSS}&quot;,&quot;level&quot;:&quot;%level&quot;,&quot;thread&quot;:&quot;%thread&quot;,&quot;logger&quot;:&quot;%logger{36}&quot;,&quot;method&quot;:&quot;%method&quot;,&quot;message&quot;:&quot;%message&quot;,&quot;params&quot;:&quot;%X{params}&quot;}%n" />
-
-        <!-- Loki Appender 설정 (운영 환경) -->
-        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-            <http>
-                <url>${LOKI_URL}</url>
-                <connectionTimeoutMs>5000</connectionTimeoutMs>
-                <requestTimeoutMs>10000</requestTimeoutMs>
-            </http>
-            <format>
-                <label>
-                    <pattern>app=${LOG_FILE_NAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
-                </label>
-                <message>
-                    <pattern>${LOG_PATTERN}</pattern>
-                </message>
-                <sortByTime>true</sortByTime>
-            </format>
-            <primarySwitch>
-                <disableOnError>true</disableOnError>
-                <silentFallback>true</silentFallback>
-            </primarySwitch>
-            <verbose>true</verbose>
-            <metricsEnabled>true</metricsEnabled>
-            <batchSize>1000</batchSize>
-            <batchTimeoutMs>10000</batchTimeoutMs>
-            <drainOnStop>true</drainOnStop>
-            <retryCount>3</retryCount>
-            <waitBetweenRetries>2000</waitBetweenRetries>
-        </appender>
 
         <!-- 운영 환경: 활성 로그는 logs/앱이름-info.log, 롤링 시 logs/날짜/앱이름-info.log -->
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -212,17 +216,20 @@
             <appender-ref ref="FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="com.wherecar.error" level="ERROR" additivity="false">
             <appender-ref ref="ERROR_FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 운영 환경 SQL 로깅 - 필수 SQL 쿼리만 기록 -->
         <logger name="org.hibernate.SQL" level="INFO">
             <appender-ref ref="QUERY_FILE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 운영 환경 루트 로거 - 간결한 로깅 -->
@@ -230,6 +237,7 @@
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="FILE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </root>
     </springProfile>
 

--- a/docker/config/logstash/pipeline/logstash.conf
+++ b/docker/config/logstash/pipeline/logstash.conf
@@ -2,14 +2,34 @@ input {
   beats {
     port => 5044
   }
+
+  tcp {
+    port => 5000
+    codec => json_lines
+  }
 }
 
 filter {
-  # 로그 형식이 JSON인 경우 추가
+  # JSON 처리 로직 개선
   if [message] =~ /^\{.*\}$/ {
     json {
       source => "message"
       skip_on_invalid_json => true
+      target => "parsed_json"
+    }
+    # 파싱된 JSON 필드들을 루트 레벨로 복사
+    if [parsed_json] {
+      ruby {
+        code => "
+          parsed = event.get('parsed_json')
+          if parsed.is_a?(Hash)
+            parsed.each do |k,v|
+              event.set(k, v) unless k == 'message' || k == '@timestamp'
+            end
+          end
+          event.remove('parsed_json')
+        "
+      }
     }
   } else {
     grok {
@@ -26,8 +46,8 @@ filter {
       "yyyy-MM-dd'T'HH:mm:ss.SSSZ"
     ]
     target => "@timestamp"
-    timezone => "Asia/Seoul"  # 추가: 시간대 설정
-    locale => "en"            # 추가: 로케일 설정
+    timezone => "Asia/Seoul"
+    locale => "en"
   }
 
   # 타임스탬프 디버그 필드 추가
@@ -38,20 +58,24 @@ filter {
     "
   }
 
-  # app_name 필드 처리 개선
-  if [app_name] {
-    mutate {
-      add_field => { "app" => "%{app_name}" }
-    }
-  } else if [fields][app_name] {
-    mutate {
-      add_field => { "app" => "%{[fields][app_name]}" }
-      add_field => { "app_name" => "%{[fields][app_name]}" }
-    }
-  } else {
-    mutate {
-      add_field => { "app" => "unknown" }
-      add_field => { "app_name" => "unknown" }
+  # app 필드 처리 개선 (중복 제거)
+  if ![app] {
+    if [fields][app_name] {
+      mutate {
+        add_field => { "app" => "%{[fields][app_name]}" }
+      }
+    } else if [fields][app] {
+      mutate {
+        add_field => { "app" => "%{[fields][app]}" }
+      }
+    } else if [customFields][app] {
+      mutate {
+        add_field => { "app" => "%{[customFields][app]}" }
+      }
+    } else {
+      mutate {
+        add_field => { "app" => "unknown" }
+      }
     }
   }
 
@@ -65,7 +89,6 @@ filter {
   ruby {
     code => "
       event.set('debug_app', event.get('app'))
-      event.set('debug_app_name', event.get('app_name'))
     "
   }
 }
@@ -75,9 +98,9 @@ output {
     hosts => ["http://elasticsearch:9200"]
     user => "${ELASTICSEARCH_USERNAME}"
     password => "${ELASTICSEARCH_PASSWORD}"
-    index => "wherecar-%{app}-%{+YYYY.MM.dd}"
+    index => "wherecar-%{[app]}-%{+YYYY.MM.dd}"
     ssl_certificate_verification => false
-    timeout => 60     # 추가: 타임아웃 설정
+    timeout => 60
   }
 
   # 디버깅용 stdout 출력 추가

--- a/docker/config/loki/local-config.yml
+++ b/docker/config/loki/local-config.yml
@@ -1,10 +1,35 @@
+# 인증 설정: 현재는 비활성화되어 있지만, 배포 환경에서는 보안을 위해 활성화 권장
 auth_enabled: false
 
 server:
   http_listen_port: 3100
-  grpc_listen_port: 9096
+  log_level: info
+  http_server_read_timeout: 120s
+  http_server_write_timeout: 120s
+  grpc_server_max_recv_msg_size: 8388608
+  grpc_server_max_send_msg_size: 8388608
 
+limits_config:
+  volume_enabled: true
+  # 인제스트 속도 제한 (초당 10MB, 버스트 20MB)
+  ingestion_rate_mb: 10
+  ingestion_burst_size_mb: 20
+  # 스트림별 속도 제한
+  per_stream_rate_limit: 10MB
+  per_stream_rate_limit_burst: 20MB
+  # 사용자당 최대 스트림 수
+  max_global_streams_per_user: 50000
+  # 쿼리 제한
+  max_query_length: 720h
+  max_query_parallelism: 32
+  # 카디널리티 제한
+  cardinality_limit: 100000
+  # 로그 보관 기간 (30일)
+  retention_period: 720h
+
+# 공통 설정: 인스턴스 주소, 경로, 스토리지, 복제
 common:
+  instance_addr: 127.0.0.1
   path_prefix: /loki
   storage:
     filesystem:
@@ -16,33 +41,79 @@ common:
     kvstore:
       store: inmemory
 
+# 스키마 설정: 인덱스, 저장소 유형 등
 schema_config:
   configs:
     - from: 2020-10-24
-      store: boltdb-shipper
+      store: tsdb
       object_store: filesystem
-      schema: v11
+      schema: v13
       index:
         prefix: index_
         period: 24h
 
-ruler:
-  alertmanager_url: http://alertmanager:9093
+# 쿼리 캐시 설정: 반복 쿼리 성능 향상을 위한 캐싱
+query_range:
+  results_cache:
+    cache:
+      embedded_cache:
+        enabled: true
+        max_size_mb: 100
+        ttl: 24h
+  # 쿼리 최적화
+  align_queries_with_step: true
+  cache_results: true
+  max_retries: 5
 
-limits_config:
-  retention_period: 7d
-
+# 청크 저장소 설정: 청크 캐싱, 조회 기간 등
 chunk_store_config:
-  max_look_back_period: 336h
+  chunk_cache_config:
+    embedded_cache:
+      enabled: true
+      max_size_mb: 200
+      ttl: 24h
 
-table_manager:
-  retention_deletes_enabled: true
-  retention_period: 336h
+# 인제스터 설정: 청크 관리 및 수명주기
+ingester:
+  chunk_idle_period: 1h
+  chunk_target_size: 1536000
+  chunk_retain_period: 30s
+  max_chunk_age: 2h
+  lifecycler:
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
 
+# 컴팩터 설정: 로그 압축 및 보존 정책
 compactor:
   working_directory: /loki/compactor
-  shared_store: filesystem
-  compaction_interval: 10m
+  compaction_interval: 5m
   retention_enabled: true
   retention_delete_delay: 2h
   retention_delete_worker_count: 150
+  delete_request_store: filesystem
+
+# 프론트엔드 설정: 응답 압축, 쿼리 로깅 등
+frontend:
+  compress_responses: true
+  log_queries_longer_than: 10s
+  max_outstanding_per_tenant: 2048
+
+# 프론트엔드 워커 설정
+frontend_worker:
+  grpc_client_config:
+    max_send_msg_size: 8388608
+
+# 룰러 설정: 알림 규칙 관리
+ruler:
+  alertmanager_url: http://localhost:9093
+  enable_api: true
+  storage:
+    type: local
+    local:
+      directory: /loki/rules
+
+# 분석 설정: 익명 사용 통계 비활성화
+analytics:
+  reporting_enabled: false

--- a/docker/docker-compose-monitoring.yml
+++ b/docker/docker-compose-monitoring.yml
@@ -49,13 +49,12 @@ services:
       resources:
         limits:
           cpus: '0.3'
-          memory: 800M
+          memory: 1024M
         reservations:
           memory: 600M
     ports:
       - "5044:5044"
-      - "5001:5000/tcp"
-      - "5001:5000/udp"
+      - "5100:5000"
       - "9600:9600"
     networks:
       - where-car-network
@@ -75,9 +74,9 @@ services:
       resources:
         limits:
           cpus: '0.3'
-          memory: 768M
+          memory: 1024M
         reservations:
-          memory: 384M
+          memory: 512M
     networks:
       - where-car-network
     depends_on:

--- a/docker/docker-compose-monitoring.yml
+++ b/docker/docker-compose-monitoring.yml
@@ -2,14 +2,14 @@ services:
 
   # ELK Stack
   elasticsearch:
-    image: elasticsearch:8.12.1
+    image: elasticsearch:8.18.0
     container_name: elasticsearch
     environment:
       - node.name=elasticsearch
       - cluster.name=wherecar-es-cluster
       - discovery.type=single-node
       - bootstrap.memory_lock=true
-      - "ES_JAVA_OPTS=-Xms2g -Xmx2g"
+      - "ES_JAVA_OPTS=-Xms2g -Xmx3g"
       - xpack.security.enabled=true
       - ELASTIC_PASSWORD=${ELASTICSEARCH_PASSWORD}
     ulimits:
@@ -20,9 +20,9 @@ services:
       resources:
         limits:
           cpus: '0.7'
-          memory: 2500M
+          memory: 3G
         reservations:
-          memory: 1500M
+          memory: 2G
     volumes:
       - elasticsearch-data:/usr/share/elasticsearch/data
     ports:
@@ -32,7 +32,7 @@ services:
       - where-car-network
 
   logstash:
-    image: docker.elastic.co/logstash/logstash:8.12.1
+    image: logstash:8.18.0
     platform: linux/arm64
     container_name: logstash
     restart: unless-stopped
@@ -63,7 +63,7 @@ services:
       - elasticsearch
 
   kibana:
-    image: kibana:8.12.1
+    image: kibana:8.18.0
     container_name: kibana
     ports:
       - "5601:5601"
@@ -83,9 +83,32 @@ services:
     depends_on:
       - elasticsearch
 
+  #  filebeat: develop your own
+  #    image: elastic/filebeat:9.0.1
+  #    container_name: filebeat
+  #    user: root
+  #    volumes:
+  #      - ./config/filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
+  #      - ../logs:/logs:ro
+  #      - filebeat-data:/usr/share/filebeat/data
+  #      - ../logs/filebeat-logs:/var/log/filebeat
+  #    command: ["filebeat", "-e", "-strict.perms=false"]
+  #    environment:
+  #      - ELASTICSEARCH_HOSTS=${ELASTICSEARCH_HOSTS}
+  #      - ELASTICSEARCH_USERNAME=${ELASTICSEARCH_USERNAME}
+  #      - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_PASSWORD}
+  #      - LOGSTASH_HOST=${LOGSTASH_HOST}
+  #      - ELASTIC_SEARCH_VERIFY_CERTS=false
+  #    networks:
+  #      - where-car-network
+  #    depends_on:
+  #      - elasticsearch
+  #      - logstash
+  #    restart: unless-stopped
+
   # Grafana Loki stack
   prometheus:
-    image: prom/prometheus:v2.49.0
+    image: prom/prometheus:v3.3.1
     container_name: prometheus
     ports:
       - "9090:9090"
@@ -103,28 +126,8 @@ services:
       - where-car-network
     restart: unless-stopped
 
-  loki:
-    image: grafana/loki:2.9.4
-    container_name: loki
-    deploy:
-      resources:
-        limits:
-          cpus: '0.2'
-          memory: 512M
-        reservations:
-          memory: 256M
-    ports:
-      - "3100:3100"
-    command: -config.file=/etc/loki/local-config.yml
-    volumes:
-      - loki-data:/loki
-      - ./config/loki:/etc/loki
-    networks:
-      - where-car-network
-    restart: unless-stopped
-
   grafana:
-    image: grafana/grafana:10.3.3
+    image: grafana/grafana:12.0.0
     container_name: grafana
     deploy:
       resources:
@@ -151,29 +154,25 @@ services:
       - loki
       - elasticsearch
 
-  # [filebeat] 개발 환경에서만 사용함 배포 환경의 경우는 다른 기술을 사용할 예정임
-  #  filebeat:
-  #    image: elastic/filebeat:8.12.1
-  #    container_name: filebeat
-  #    user: root
-  #    volumes:
-  #      - ./config/filebeat/filebeat.yml:/usr/share/filebeat/filebeat.yml:ro
-  #      - ../logs:/logs:ro
-  #      - filebeat-data:/usr/share/filebeat/data
-  #      - ../logs/filebeat-logs:/var/log/filebeat
-  #    command: ["filebeat", "-e", "-strict.perms=false"]
-  #    environment:
-  #      - ELASTICSEARCH_HOSTS=${ELASTICSEARCH_HOSTS}
-  #      - ELASTICSEARCH_USERNAME=${ELASTICSEARCH_USERNAME}
-  #      - ELASTICSEARCH_PASSWORD=${ELASTICSEARCH_PASSWORD}
-  #      - LOGSTASH_HOST=${LOGSTASH_HOST}
-  #      - ELASTIC_SEARCH_VERIFY_CERTS=false
-  #    networks:
-  #      - where-car-network
-  #    depends_on:
-  #      - elasticsearch
-  #      - logstash
-  #    restart: unless-stopped
+  loki:
+    image: grafana/loki:3.5
+    container_name: loki
+    deploy:
+      resources:
+        limits:
+          cpus: '0.2'
+          memory: 512M
+        reservations:
+          memory: 256M
+    ports:
+      - "3100:3100"
+    command: -config.file=/etc/loki/local-config.yml -config.expand-env=true
+    volumes:
+      - loki-data:/loki
+      - ./config/loki:/etc/loki
+    networks:
+      - where-car-network
+    restart: unless-stopped
 
 networks:
   where-car-network:
@@ -188,5 +187,5 @@ volumes:
     driver: local
   loki-data:
     driver: local
-#  filebeat-data:
+#  filebeat-data: develop your own
 #    driver: local

--- a/hub/src/main/resources/application-dev.yml
+++ b/hub/src/main/resources/application-dev.yml
@@ -23,3 +23,12 @@ management:
     tags:
       application: ${spring.application.name}
       environment: ${spring.profiles.active}
+
+monitoring:
+  loki:
+    host: http://localhost
+    port: 3100
+    endpoint: /loki/api/v1/push
+  logstash:
+    host: localhost
+    port: 5100

--- a/hub/src/main/resources/application-prod.yml
+++ b/hub/src/main/resources/application-prod.yml
@@ -30,4 +30,9 @@ management:
 
 monitoring:
   loki:
-    url: ${LOKI_URL}
+    host: ${LOKI_HOST}
+    post: ${LOKI_PORT}
+    endpoint: ${LOKI_ENDPOINT}
+  logstash:
+    host: ${LOGSTASH_HOST}
+    port: ${LOGSTASH_PORT}

--- a/hub/src/main/resources/logback-spring.xml
+++ b/hub/src/main/resources/logback-spring.xml
@@ -3,7 +3,11 @@
     <!-- 공통 속성 정의 -->
     <springProperty scope="context" name="LOG_FILE_NAME" source="spring.application.name" defaultValue="application"/>
     <springProperty scope="context" name="ACTIVE_PROFILE" source="spring.profiles.active" defaultValue="dev"/>
-    <springProperty scope="context" name="LOKI_URL" source="monitoring.loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+    <springProperty scope="context" name="LOKI_HOST" source="monitoring.loki.host" defaultValue="http://localhost"/>
+    <springProperty scope="context" name="LOKI_PORT" source="monitoring.loki.port" defaultValue="3100"/>
+    <springProperty scope="context" name="LOKI_ENDPOINT" source="monitoring.loki.endpoint" defaultValue="/loki/api/v1/push"/>
+    <springProperty scope="context" name="LOGSTASH_HOST" source="monitoring.logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="LOGSTASH_PORT" source="monitoring.logstash.port" defaultValue="5044"/>
     <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}][%-5level][%logger{36}][%method] %msg | %X{params} %n" />
     <property name="LOG_PATTERN_COLOR" value="%magenta([%d{yyyy-MM-dd HH:mm:ss}]) %highlight([%-5level]) %green([%logger{36}]) %yellow([%method]) %msg | %X{params} %n" />
 
@@ -15,39 +19,63 @@
         </encoder>
     </appender>
 
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_HOST}:${LOKI_PORT}${LOKI_ENDPOINT}</url>
+            <connectionTimeoutMs>5000</connectionTimeoutMs>
+            <requestTimeoutMs>10000</requestTimeoutMs>
+        </http>
+        <format>
+            <label>
+                <pattern>app=${LOG_FILE_NAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
+            </label>
+            <message>
+                <pattern>${LOG_PATTERN}</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+        <primarySwitch>
+            <disableOnError>true</disableOnError>
+            <silentFallback>true</silentFallback>
+        </primarySwitch>
+        <verbose>false</verbose> // Debugging mode
+        <metricsEnabled>true</metricsEnabled>
+        <batchSize>1000</batchSize>
+        <batchTimeoutMs>10000</batchTimeoutMs>
+        <drainOnStop>true</drainOnStop>
+        <retryCount>3</retryCount>
+        <waitBetweenRetries>2000</waitBetweenRetries>
+    </appender>
+
+    <!-- Logstash Appender (공식 권장 설정) -->
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${LOGSTASH_HOST}:${LOGSTASH_PORT}</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"app":"${LOG_FILE_NAME}","env":"${ACTIVE_PROFILE}","service":"where-car"}</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <shortenedLoggerNameLength>36</shortenedLoggerNameLength>
+            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                <maxLength>4096</maxLength>
+                <shortenedClassNameLength>36</shortenedClassNameLength>
+                <rootCauseFirst>true</rootCauseFirst>
+            </throwableConverter>
+        </encoder>
+        <reconnectionDelay>1 second</reconnectionDelay>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
+        <connectionStrategy>
+            <roundRobin>
+                <connectionTTL>5 minutes</connectionTTL>
+            </roundRobin>
+        </connectionStrategy>
+    </appender>
+
     <!-- 개발 환경 설정 -->
     <springProfile name="dev">
         <!-- 개발 환경 속성 -->
         <property name="LOG_PATH" value="logs" />
         <property name="LOG_LEVEL" value="DEBUG" />
-
-        <!-- Loki Appender 설정 (개발 환경) -->
-        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-            <http>
-                <url>${LOKI_URL}</url>
-                <connectionTimeoutMs>5000</connectionTimeoutMs>
-                <requestTimeoutMs>10000</requestTimeoutMs>
-            </http>
-            <format>
-                <label>
-                    <pattern>app=${LOG_FILE_NAME},host=${HOSTNAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
-                </label>
-                <message>
-                    <pattern>${LOG_PATTERN}</pattern>
-                </message>
-                <sortByTime>true</sortByTime>
-            </format>
-            <primarySwitch>
-                <disableOnError>true</disableOnError>
-                <silentFallback>true</silentFallback>
-            </primarySwitch>
-            <verbose>false</verbose>
-            <metricsEnabled>true</metricsEnabled>
-            <batchSize>100</batchSize>
-            <batchTimeoutMs>10000</batchTimeoutMs>
-            <retryCount>2</retryCount>
-            <waitBetweenRetries>1000</waitBetweenRetries>
-        </appender>
 
         <!-- 개발 환경: 활성 로그는 logs/앱이름/앱이름-info.log, 롤링 시 logs/앱이름/날짜/앱이름-info.log -->
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -96,23 +124,27 @@
             <appender-ref ref="FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="com.wherecar.error" level="ERROR" additivity="false">
             <appender-ref ref="ERROR_FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 개발 환경 SQL 로깅 - 모든 SQL 쿼리 기록 -->
         <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
             <appender-ref ref="QUERY_FILE" />
             <appender-ref ref="CONSOLE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="org.hibernate.type.descriptor.sql" level="TRACE" additivity="false">
             <appender-ref ref="QUERY_FILE" />
             <appender-ref ref="CONSOLE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 개발 환경 루트 로거 - 상세 로깅 -->
@@ -120,6 +152,7 @@
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="FILE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </root>
     </springProfile>
 
@@ -131,35 +164,6 @@
         
         <!-- JSON 형식 로그 패턴 (ELK 분석용) -->
         <property name="LOG_PATTERN_JSON" value="{&quot;timestamp&quot;:&quot;%d{yyyy-MM-dd HH:mm:ss.SSS}&quot;,&quot;level&quot;:&quot;%level&quot;,&quot;thread&quot;:&quot;%thread&quot;,&quot;logger&quot;:&quot;%logger{36}&quot;,&quot;method&quot;:&quot;%method&quot;,&quot;message&quot;:&quot;%message&quot;,&quot;params&quot;:&quot;%X{params}&quot;}%n" />
-
-        <!-- Loki Appender 설정 (운영 환경) -->
-        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-            <http>
-                <url>${LOKI_URL}</url>
-                <connectionTimeoutMs>5000</connectionTimeoutMs>
-                <requestTimeoutMs>10000</requestTimeoutMs>
-            </http>
-            <format>
-                <label>
-                    <pattern>app=${LOG_FILE_NAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
-                </label>
-                <message>
-                    <pattern>${LOG_PATTERN}</pattern>
-                </message>
-                <sortByTime>true</sortByTime>
-            </format>
-            <primarySwitch>
-                <disableOnError>true</disableOnError>
-                <silentFallback>true</silentFallback>
-            </primarySwitch>
-            <verbose>true</verbose>
-            <metricsEnabled>true</metricsEnabled>
-            <batchSize>1000</batchSize>
-            <batchTimeoutMs>10000</batchTimeoutMs>
-            <drainOnStop>true</drainOnStop>
-            <retryCount>3</retryCount>
-            <waitBetweenRetries>2000</waitBetweenRetries>
-        </appender>
 
         <!-- 운영 환경: 활성 로그는 logs/앱이름-info.log, 롤링 시 logs/날짜/앱이름-info.log -->
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -212,17 +216,20 @@
             <appender-ref ref="FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="com.wherecar.error" level="ERROR" additivity="false">
             <appender-ref ref="ERROR_FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 운영 환경 SQL 로깅 - 필수 SQL 쿼리만 기록 -->
         <logger name="org.hibernate.SQL" level="INFO">
             <appender-ref ref="QUERY_FILE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 운영 환경 루트 로거 - 간결한 로깅 -->
@@ -230,6 +237,7 @@
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="FILE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </root>
     </springProfile>
 

--- a/rest/src/main/resources/application-dev.yml
+++ b/rest/src/main/resources/application-dev.yml
@@ -44,3 +44,12 @@ management:
     tags:
       application: ${spring.application.name}
       environment: ${spring.profiles.active}
+
+monitoring:
+  loki:
+    host: http://localhost
+    port: 3100
+    endpoint: /loki/api/v1/push
+  logstash:
+    host: localhost
+    port: 5100

--- a/rest/src/main/resources/application-prod.yml
+++ b/rest/src/main/resources/application-prod.yml
@@ -64,4 +64,9 @@ management:
 
 monitoring:
   loki:
-    url: ${LOKI_URL}
+    host: ${LOKI_HOST}
+    post: ${LOKI_PORT}
+    endpoint: ${LOKI_ENDPOINT}
+  logstash:
+    host: ${LOGSTASH_HOST}
+    port: ${LOGSTASH_PORT}

--- a/rest/src/main/resources/logback-spring.xml
+++ b/rest/src/main/resources/logback-spring.xml
@@ -3,7 +3,11 @@
     <!-- 공통 속성 정의 -->
     <springProperty scope="context" name="LOG_FILE_NAME" source="spring.application.name" defaultValue="application"/>
     <springProperty scope="context" name="ACTIVE_PROFILE" source="spring.profiles.active" defaultValue="dev"/>
-    <springProperty scope="context" name="LOKI_URL" source="monitoring.loki.url" defaultValue="http://localhost:3100/loki/api/v1/push"/>
+    <springProperty scope="context" name="LOKI_HOST" source="monitoring.loki.host" defaultValue="http://localhost"/>
+    <springProperty scope="context" name="LOKI_PORT" source="monitoring.loki.port" defaultValue="3100"/>
+    <springProperty scope="context" name="LOKI_ENDPOINT" source="monitoring.loki.endpoint" defaultValue="/loki/api/v1/push"/>
+    <springProperty scope="context" name="LOGSTASH_HOST" source="monitoring.logstash.host" defaultValue="localhost"/>
+    <springProperty scope="context" name="LOGSTASH_PORT" source="monitoring.logstash.port" defaultValue="5044"/>
     <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss}][%-5level][%logger{36}][%method] %msg | %X{params} %n" />
     <property name="LOG_PATTERN_COLOR" value="%magenta([%d{yyyy-MM-dd HH:mm:ss}]) %highlight([%-5level]) %green([%logger{36}]) %yellow([%method]) %msg | %X{params} %n" />
 
@@ -15,39 +19,63 @@
         </encoder>
     </appender>
 
+    <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
+        <http>
+            <url>${LOKI_HOST}:${LOKI_PORT}${LOKI_ENDPOINT}</url>
+            <connectionTimeoutMs>5000</connectionTimeoutMs>
+            <requestTimeoutMs>10000</requestTimeoutMs>
+        </http>
+        <format>
+            <label>
+                <pattern>app=${LOG_FILE_NAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
+            </label>
+            <message>
+                <pattern>${LOG_PATTERN}</pattern>
+            </message>
+            <sortByTime>true</sortByTime>
+        </format>
+        <primarySwitch>
+            <disableOnError>true</disableOnError>
+            <silentFallback>true</silentFallback>
+        </primarySwitch>
+        <verbose>false</verbose> // Debugging mode
+        <metricsEnabled>true</metricsEnabled>
+        <batchSize>1000</batchSize>
+        <batchTimeoutMs>10000</batchTimeoutMs>
+        <drainOnStop>true</drainOnStop>
+        <retryCount>3</retryCount>
+        <waitBetweenRetries>2000</waitBetweenRetries>
+    </appender>
+
+    <!-- Logstash Appender (공식 권장 설정) -->
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>${LOGSTASH_HOST}:${LOGSTASH_PORT}</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+            <customFields>{"app":"${LOG_FILE_NAME}","env":"${ACTIVE_PROFILE}","service":"where-car"}</customFields>
+            <includeMdc>true</includeMdc>
+            <includeContext>true</includeContext>
+            <shortenedLoggerNameLength>36</shortenedLoggerNameLength>
+            <throwableConverter class="net.logstash.logback.stacktrace.ShortenedThrowableConverter">
+                <maxDepthPerThrowable>30</maxDepthPerThrowable>
+                <maxLength>4096</maxLength>
+                <shortenedClassNameLength>36</shortenedClassNameLength>
+                <rootCauseFirst>true</rootCauseFirst>
+            </throwableConverter>
+        </encoder>
+        <reconnectionDelay>1 second</reconnectionDelay>
+        <keepAliveDuration>5 minutes</keepAliveDuration>
+        <connectionStrategy>
+            <roundRobin>
+                <connectionTTL>5 minutes</connectionTTL>
+            </roundRobin>
+        </connectionStrategy>
+    </appender>
+
     <!-- 개발 환경 설정 -->
     <springProfile name="dev">
         <!-- 개발 환경 속성 -->
         <property name="LOG_PATH" value="logs" />
         <property name="LOG_LEVEL" value="DEBUG" />
-
-        <!-- Loki Appender 설정 (개발 환경) -->
-        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-            <http>
-                <url>${LOKI_URL}</url>
-                <connectionTimeoutMs>5000</connectionTimeoutMs>
-                <requestTimeoutMs>10000</requestTimeoutMs>
-            </http>
-            <format>
-                <label>
-                    <pattern>app=${LOG_FILE_NAME},host=${HOSTNAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
-                </label>
-                <message>
-                    <pattern>${LOG_PATTERN}</pattern>
-                </message>
-                <sortByTime>true</sortByTime>
-            </format>
-            <primarySwitch>
-                <disableOnError>true</disableOnError>
-                <silentFallback>true</silentFallback>
-            </primarySwitch>
-            <verbose>false</verbose>
-            <metricsEnabled>true</metricsEnabled>
-            <batchSize>100</batchSize>
-            <batchTimeoutMs>10000</batchTimeoutMs>
-            <retryCount>2</retryCount>
-            <waitBetweenRetries>1000</waitBetweenRetries>
-        </appender>
 
         <!-- 개발 환경: 활성 로그는 logs/앱이름/앱이름-info.log, 롤링 시 logs/앱이름/날짜/앱이름-info.log -->
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -96,23 +124,27 @@
             <appender-ref ref="FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="com.wherecar.error" level="ERROR" additivity="false">
             <appender-ref ref="ERROR_FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 개발 환경 SQL 로깅 - 모든 SQL 쿼리 기록 -->
         <logger name="org.hibernate.SQL" level="DEBUG" additivity="false">
             <appender-ref ref="QUERY_FILE" />
             <appender-ref ref="CONSOLE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="org.hibernate.type.descriptor.sql" level="TRACE" additivity="false">
             <appender-ref ref="QUERY_FILE" />
             <appender-ref ref="CONSOLE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 개발 환경 루트 로거 - 상세 로깅 -->
@@ -120,6 +152,7 @@
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="FILE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </root>
     </springProfile>
 
@@ -131,35 +164,6 @@
         
         <!-- JSON 형식 로그 패턴 (ELK 분석용) -->
         <property name="LOG_PATTERN_JSON" value="{&quot;timestamp&quot;:&quot;%d{yyyy-MM-dd HH:mm:ss.SSS}&quot;,&quot;level&quot;:&quot;%level&quot;,&quot;thread&quot;:&quot;%thread&quot;,&quot;logger&quot;:&quot;%logger{36}&quot;,&quot;method&quot;:&quot;%method&quot;,&quot;message&quot;:&quot;%message&quot;,&quot;params&quot;:&quot;%X{params}&quot;}%n" />
-
-        <!-- Loki Appender 설정 (운영 환경) -->
-        <appender name="LOKI" class="com.github.loki4j.logback.Loki4jAppender">
-            <http>
-                <url>${LOKI_URL}</url>
-                <connectionTimeoutMs>5000</connectionTimeoutMs>
-                <requestTimeoutMs>10000</requestTimeoutMs>
-            </http>
-            <format>
-                <label>
-                    <pattern>app=${LOG_FILE_NAME},level=%level,env=${ACTIVE_PROFILE},service=where-car</pattern>
-                </label>
-                <message>
-                    <pattern>${LOG_PATTERN}</pattern>
-                </message>
-                <sortByTime>true</sortByTime>
-            </format>
-            <primarySwitch>
-                <disableOnError>true</disableOnError>
-                <silentFallback>true</silentFallback>
-            </primarySwitch>
-            <verbose>true</verbose>
-            <metricsEnabled>true</metricsEnabled>
-            <batchSize>1000</batchSize>
-            <batchTimeoutMs>10000</batchTimeoutMs>
-            <drainOnStop>true</drainOnStop>
-            <retryCount>3</retryCount>
-            <waitBetweenRetries>2000</waitBetweenRetries>
-        </appender>
 
         <!-- 운영 환경: 활성 로그는 logs/앱이름-info.log, 롤링 시 logs/날짜/앱이름-info.log -->
         <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
@@ -212,17 +216,20 @@
             <appender-ref ref="FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <logger name="com.wherecar.error" level="ERROR" additivity="false">
             <appender-ref ref="ERROR_FILE" />
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 운영 환경 SQL 로깅 - 필수 SQL 쿼리만 기록 -->
         <logger name="org.hibernate.SQL" level="INFO">
             <appender-ref ref="QUERY_FILE" />
+            <appender-ref ref="LOGSTASH" />
         </logger>
 
         <!-- 운영 환경 루트 로거 - 간결한 로깅 -->
@@ -230,6 +237,7 @@
             <appender-ref ref="CONSOLE" />
             <appender-ref ref="FILE" />
             <appender-ref ref="LOKI" />
+            <appender-ref ref="LOGSTASH" />
         </root>
     </springProfile>
 


### PR DESCRIPTION
## 📝 작업 내용

로키의 환결 변수를 수정하고
ELK 로그를 대응할 수 있도록 수정했습니다.

현재 서버 관제(모니터링)은 다음과 같습니다.

서버 -> 로키 -> 그라파냐
서버 -> 로그스태시 -> 엘라스틱서치 -> 키바나

