### PR TITLE
[#294] fix: drive type 오류 수정

### DIFF
--- a/batch/src/main/java/com/wherecar/batch/stat/application/CarLogSummaryBatch.java
+++ b/batch/src/main/java/com/wherecar/batch/stat/application/CarLogSummaryBatch.java
@@ -3,6 +3,7 @@ package com.wherecar.batch.stat.application;
 import com.wherecar.batch.main.domain.Car;
 import com.wherecar.batch.main.domain.CarLog;
 import com.wherecar.batch.main.domain.GpsLog;
+import com.wherecar.batch.main.domain.constant.DriveType;
 import com.wherecar.batch.main.infrastructure.CarLogRepository;
 import com.wherecar.batch.main.infrastructure.CarRepository;
 import com.wherecar.batch.main.infrastructure.GpsLogRepository;
@@ -145,7 +146,7 @@ public class CarLogSummaryBatch {
                     .onLongitude(carLog.getOnLongitude())
                     .offLatitude(carLog.getOffLatitude())
                     .offLongitude(carLog.getOffLongitude())
-                    .driveType(carLog.getDriveType())
+                    .driveType(carLog.getDriveType() != null ? carLog.getDriveType() : DriveType.UNCLASSIFIED)
                     .distance((int)(carLog.getOffMileage() - carLog.getOnMileage()))
                     .averageSpeed(avgSpeed)
                     .maxSpeed((int) maxSpeed)

--- a/collector/src/main/java/com/wherecar/collector/carlog/domain/CarLogFactory.java
+++ b/collector/src/main/java/com/wherecar/collector/carlog/domain/CarLogFactory.java
@@ -1,6 +1,7 @@
 package com.wherecar.collector.carlog.domain;
 
 import com.wherecar.collector.carlog.application.dto.CarLogRequest;
+import com.wherecar.collector.common.constant.DriveType;
 import com.wherecar.collector.common.constant.GpsConditionType;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -20,16 +21,17 @@ public class CarLogFactory {
         GpsConditionType onGpsCondition = CarLog.getGpsConditionType(carLogRequest.getGcd());
 
         return CarLog.builder()
-            .mdn(carLogRequest.getMdn())
-            .onGpsCondition(onGpsCondition)
-            .onLatitude(doubleLatitude)
-            .onLongitude(doubleLongitude)
-            .onAngle(Integer.parseInt(carLogRequest.getAng()))
-            .onSpeed(Integer.parseInt(carLogRequest.getSpd()))
-            .onSum(Integer.parseInt(carLogRequest.getSum()))
-            .onMileage(onMileage)
-            .onTime(onTime)
-            .build();
+                .driveType(DriveType.UNCLASSIFIED)
+                .mdn(carLogRequest.getMdn())
+                .onGpsCondition(onGpsCondition)
+                .onLatitude(doubleLatitude)
+                .onLongitude(doubleLongitude)
+                .onAngle(Integer.parseInt(carLogRequest.getAng()))
+                .onSpeed(Integer.parseInt(carLogRequest.getSpd()))
+                .onSum(Integer.parseInt(carLogRequest.getSum()))
+                .onMileage(onMileage)
+                .onTime(onTime)
+                .build();
     }
 
     public CarLog toFirstOnLog(CarLogRequest carLogRequest) {
@@ -43,6 +45,7 @@ public class CarLogFactory {
         GpsConditionType onGpsCondition = CarLog.getGpsConditionType(carLogRequest.getGcd());
 
         return CarLog.builder()
+                .driveType(DriveType.UNCLASSIFIED)
                 .mdn(carLogRequest.getMdn())
                 .onGpsCondition(onGpsCondition)
                 .onLatitude(doubleLatitude)

--- a/collector/src/main/java/com/wherecar/collector/common/constant/DriveType.java
+++ b/collector/src/main/java/com/wherecar/collector/common/constant/DriveType.java
@@ -1,6 +1,8 @@
 package com.wherecar.collector.common.constant;
 
 public enum DriveType {
+    UNCLASSIFIED,
     COMMUTE,
-    WORK
+    BUSINESS,
+    PERSONAL
 }

--- a/rest/src/main/java/com/wherecar/rest/carlogsummary/domain/CarLogSummaryFactory.java
+++ b/rest/src/main/java/com/wherecar/rest/carlogsummary/domain/CarLogSummaryFactory.java
@@ -40,12 +40,17 @@ public class CarLogSummaryFactory {
             totalDistance += carLogSummary.getDistance();
             totalDriveTime += (int) Duration.between(carLogSummary.getOnTime(),carLogSummary.getOffTime()).toSeconds();
 
-            switch (carLogSummary.getDriveType()) {
-                case UNCLASSIFIED -> unclassifiedCount++;
-                case PERSONAL     -> personalCount++;
-                case COMMUTE      -> commuteCount++;
-                case BUSINESS     -> businessCount++;
+            if(carLogSummary.getDriveType()==null){
+                unclassifiedCount++;
+            } else {
+                switch (carLogSummary.getDriveType()) {
+                    case UNCLASSIFIED -> unclassifiedCount++;
+                    case PERSONAL     -> personalCount++;
+                    case COMMUTE      -> commuteCount++;
+                    case BUSINESS     -> businessCount++;
+                }
             }
+
 
 
             onList.add(GpsPoint.builder()


### PR DESCRIPTION
close #294

## 📝 작업 내용

- `CarLogSummaryBuilder`에서 `driveType`이 `null`인 경우 `DriveType.UNCLASSIFIED`로 기본값 설정
  ```java
  .driveType(carLog.getDriveType() != null ? carLog.getDriveType() : DriveType.UNCLASSIFIED)
  ```
- `CarLogFactory.toOnLog`, `toFirstOnLog` 메서드에서 `driveType` 기본값을 `DriveType.UNCLASSIFIED`로 설정
- `DriveType` enum에 누락된 값 `BUSINESS`, `PERSONAL` 추가
- `CarLogSummaryFactory.toCarLogSummaryOverviewResponse`에서 `null` 예외 방지를 위한 `switch` 조건 수정

## 💬 리뷰 요구사항

- `DriveType`의 기본값 처리 방식에 대해 더 나은 패턴이 있다면 의견 부탁드립니다.
- 통합 enum 정리가 필요한지 확인 부탁드립니다 (`collector.common.constant.DriveType` 등 중복 여부)

## 📍 기타

- 위 수정은 통계 처리 시 `NullPointerException` 방지를 목적으로 하며, batch 및 collector 공통 영역에서 일관된 처리 방식을 적용했습니다.


